### PR TITLE
Fix load_plugins should return empty dict for no plugins

### DIFF
--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -77,7 +77,7 @@ def load_plugins():
     try:
         plugin_configuration = Configuration().Plugins
     except AttributeError:
-        return []
+        return {}
     else:
         def create_instance(plugin):
             return getattr(import_module(name=f"tardis.plugins.{plugin.lower()}"), f'{plugin}')()

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -35,5 +35,5 @@ class TestPoolFactory(TestCase):
         self.assertEqual(load_plugins(), {'SqliteRegistry': self.mock_sqliteregistry()})
 
         self.mock_config.side_effect = AttributeError
-        load_plugins()
+        self.assertEqual(load_plugins(), {})
         self.mock_config.side_effect = None


### PR DESCRIPTION
- Load plugins should return empty dictionary, if no plugins are enabled.