### PR TITLE
Handle draining of non existing machines properly

### DIFF
--- a/tardis/adapter/htcondor.py
+++ b/tardis/adapter/htcondor.py
@@ -65,6 +65,7 @@ class HTCondorAdapter(BatchSystemAdapter):
                 # https://github.com/htcondor/htcondor/blob/master/src/condor_tools/drain.cpp
                 logging.debug("Drone %s is not in HTCondor anymore." % dns_name)
                 return
+            raise ex
 
     async def integrate_machine(self, dns_name):
         """

--- a/tests/adapter_t/test_htcondor.py
+++ b/tests/adapter_t/test_htcondor.py
@@ -52,6 +52,18 @@ class TestHTCondorAdapter(TestCase):
         run_async(self.htcondor_adapter.drain_machine, dns_name='test')
         self.mock_async_run_command.assert_called_with('condor_drain -graceful test')
         self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="not_exists"))
+        self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Does not exists",
+                                                                         error_code=1,
+                                                                         error_message="Does not exists")
+        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="test"))
+
+        self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Unhandled error",
+                                                                         error_code=2,
+                                                                         error_message="Unhandled error")
+        with self.assertRaises(AsyncRunCommandFailure):
+            self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="test"))
+
+        self.mock_async_run_command.side_effect = None
 
     def test_integrate_machine(self):
         self.assertIsNone(run_async(self.htcondor_adapter.integrate_machine, dns_name='test'))


### PR DESCRIPTION
- Add unittest for newly added code
-  Handle draining of machines that does not exist anymore in HTCondor properly