### PR TITLE
Enable python3.7 for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.7-dev"
   - "3.6"
   - "3.6-dev" # 3.6 development branch
   - "nightly" # currently points to 3.7-dev
@@ -9,14 +8,15 @@ python:
 
 os:
   - linux
-#  - osx
 
 matrix:
   allow_failures:
-  - python: "3.7-dev"
   - python: "3.6-dev"
   - python: "nightly"
   - python: "pypy3.5"
+  include:
+    - python: 3.7
+      dist: xenial
 
 install:
   - pip install codecov


### PR DESCRIPTION
Try to use xenia distribution, to enable unittests with python3.7!