### PR TITLE
Refactoring drone states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# test database
+tests/plugins_t/test.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 install:
   - pip install codecov
   - pip install coverage
-  - pip install git+https://github.com/MaineKuehn/cobald.git
+  - pip install git+https://github.com/MatterMiners/cobald.git
 
 script:
   - coverage run setup.py test

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - tests

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Framework :: AsyncIO',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='asyncio tardis cloud scheduler',
     packages=find_packages(exclude=['tests']),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='StateMachine using asyncio',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/giffels/AsyncStateMachine',
+    url='https://github.com/tardis-resourcemanager/tardis',
     author='Manuel Giffels',
     author_email='giffels@gmail.com',
     classifiers=[
@@ -37,7 +37,7 @@ setup(
     zip_safe=False,
     test_suite='tests',
     project_urls={
-        'Bug Reports': 'https://github.com/giffels/AsyncStateMachine/issues',
-        'Source': 'https://github.com/giffels/AsyncStateMachine',
+        'Bug Reports': 'https://github.com/tardis-resourcemanager/tardis/issues',
+        'Source': 'https://github.com/tardis-resourcemanager/tardis',
     },
 )

--- a/tardis/adapter/openstack.py
+++ b/tardis/adapter/openstack.py
@@ -51,8 +51,8 @@ class OpenStackAdapter(SiteAdapter):
                                        translator_functions=translator_functions)
 
     async def deploy_resource(self, resource_attributes):
-        specs = self.configuration.MachineTypeConfiguration[self._machine_type]
-        specs['name'] = resource_attributes.dns_name
+        specs = dict(name=resource_attributes.dns_name)
+        specs.update(self.configuration.MachineTypeConfiguration[self._machine_type])
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.create(server=specs)
         logging.debug(f"{self.site_name} servers create returned {response}")

--- a/tardis/interfaces/state.py
+++ b/tardis/interfaces/state.py
@@ -1,5 +1,4 @@
 from ..utilities.pipeline import PipelineProcessor
-from ..utilities.pipeline import StopProcessing
 
 from abc import ABCMeta, abstractmethod
 
@@ -25,8 +24,5 @@ class State(metaclass=ABCMeta):
 
     @classmethod
     async def run_processing_pipeline(cls, drone):
-        try:
-            pipeline_processor = PipelineProcessor(cls.processing_pipeline)
-            return await pipeline_processor.run_pipeline(pipeline_input=cls.transition, drone=drone, current_state=cls)
-        except StopProcessing as ex:
-            return ex.last_result
+        pipeline_processor = PipelineProcessor(cls.processing_pipeline)
+        return await pipeline_processor.run_pipeline(pipeline_input=cls.transition, drone=drone, current_state=cls)

--- a/tardis/interfaces/state.py
+++ b/tardis/interfaces/state.py
@@ -1,8 +1,12 @@
+from ..utilities.pipeline import PipelineProcessor
+from ..utilities.pipeline import StopProcessing
+
 from abc import ABCMeta, abstractmethod
 
 
 class State(metaclass=ABCMeta):
     transition = {}
+    processing_pipeline = []
 
     def __str__(self):
         return self.__class__.__name__
@@ -14,7 +18,15 @@ class State(metaclass=ABCMeta):
     def get_all_states(cls):
         return [subclass.__name__ for subclass in cls.__subclasses__()]
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    async def run(drone):
+    async def run(cls, drone):
         return NotImplemented
+
+    @classmethod
+    async def run_processing_pipeline(cls, drone):
+        try:
+            pipeline_processor = PipelineProcessor(cls.processing_pipeline)
+            return await pipeline_processor.run_pipeline(pipeline_input=cls.transition, drone=drone, current_state=cls)
+        except StopProcessing as ex:
+            return ex.last_result

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -10,6 +10,8 @@ import sqlite3
 
 class SqliteRegistry(Plugin):
     def __init__(self):
+        self.logger = logging.getLogger("sqliteregistry")
+        self.logger.setLevel(logging.DEBUG)
         configuration = Configuration()
         self._db_file = configuration.Plugins.SqliteRegistry.db_file
         self._deploy_db_schema()
@@ -106,7 +108,7 @@ class SqliteRegistry(Plugin):
 
     async def notify(self, state, resource_attributes):
         state = str(state)
-        logging.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
+        self.logger.debug(f"Drone: {str(resource_attributes)} has changed state to {state}")
         bind_parameters = dict(state=state)
         bind_parameters.update(resource_attributes)
         await self._dispatch_on_state.get(state, self.update_resource)(bind_parameters)

--- a/tardis/utilities/pipeline.py
+++ b/tardis/utilities/pipeline.py
@@ -1,0 +1,30 @@
+import asyncio
+
+
+class StopProcessing(BaseException):
+    def __init__(self, last_result):
+        self._last_result = last_result
+
+    @property
+    def last_result(self):
+        return self._last_result
+
+
+class PipelineProcessor(object):
+    def __init__(self, pipeline=None):
+        self._processing_pipeline = pipeline or []
+
+    def add_to_pipeline(self, func):
+        if callable(func):
+            self._processing_pipeline.append(func)
+
+    async def run_pipeline(self, pipeline_input, *args, **kwargs):
+        try:
+            pipeline = asyncio.Future()
+            pipeline.set_result(pipeline_input)
+
+            for func_call in self._processing_pipeline:
+                pipeline = func_call(await pipeline, *args, **kwargs)
+            return await pipeline
+        except StopProcessing as ex:
+            return ex.last_result

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -1,13 +1,200 @@
+from tardis.exceptions.tardisexceptions import TardisAuthError
+from tardis.exceptions.tardisexceptions import TardisDroneCrashed
+from tardis.exceptions.tardisexceptions import TardisTimeout
+from tardis.exceptions.tardisexceptions import TardisQuotaExceeded
+from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
+from tardis.interfaces.batchsystemadapter import MachineStatus
+from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.resources.dronestates import RequestState
 from tardis.resources.dronestates import BootingState
+from tardis.resources.dronestates import IntegrateState
 from tardis.resources.dronestates import IntegratingState
 from tardis.resources.dronestates import AvailableState
+from tardis.resources.dronestates import DrainState
 from tardis.resources.dronestates import DrainingState
+from tardis.resources.dronestates import DisintegrateState
 from tardis.resources.dronestates import ShutDownState
+from tardis.resources.dronestates import ShuttingDownState
+from tardis.resources.dronestates import CleanupState
 from tardis.resources.dronestates import DownState
+from tardis.utilities.attributedict import AttributeDict
+from ..utilities.utilities import async_return
+from ..utilities.utilities import run_async
 
+from functools import partial
 from unittest import TestCase
+from unittest.mock import patch
+
+import asyncio
 
 
 class TestDroneStates(TestCase):
-    pass
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_drone_patcher = patch('tardis.resources.drone.Drone')
+        cls.mock_drone = cls.mock_drone_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_drone_patcher.stop()
+
+    def setUp(self):
+        async def mock_set_state(drone, state):
+            drone.state = state
+            f = asyncio.Future()
+            f.set_result(None)
+            return f
+
+        self.drone = self.mock_drone.return_value
+        self.drone.resource_attributes = AttributeDict(dns_name='test-923ABF', resource_id='0815')
+        self.drone.demand = 8.0
+        self.drone.set_state.side_effect = partial(mock_set_state, self.drone)
+        self.drone.site_agent.deploy_resource.return_value = async_return(return_value=AttributeDict())
+        self.drone.site_agent.resource_status.return_value = async_return(return_value=AttributeDict())
+        self.drone.site_agent.stop_resource.return_value = async_return(return_value=AttributeDict())
+        self.drone.site_agent.terminate_resource.return_value = async_return(return_value=AttributeDict())
+        self.drone.batch_system_agent.integrate_machine.return_value = async_return(return_value=None)
+        self.drone.batch_system_agent.disintegrate_machine.return_value = async_return(return_value=None)
+        self.drone.batch_system_agent.drain_machine.return_value = async_return(return_value=None)
+        self.drone.batch_system_agent.get_machine_status.return_value = async_return(return_value=None)
+        self.drone.batch_system_agent.get_allocation.return_value = async_return(return_value=None)
+        self.drone.batch_system_agent.get_utilization.return_value = async_return(return_value=None)
+
+    def run_the_matrix(self, matrix, initial_state):
+        for resource_status, machine_status, new_state in matrix:
+            self.drone.site_agent.resource_status.return_value = async_return(
+                return_value=AttributeDict(resource_status=resource_status))
+            self.drone.batch_system_agent.get_machine_status.return_value = async_return(
+                return_value=machine_status)
+            self.drone.state.return_value = initial_state
+            run_async(self.drone.state.return_value.run, self.drone)
+            self.assertIsInstance(self.drone.state, new_state)
+
+    def test_request_state(self):
+        self.drone.state.return_value = RequestState()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, BootingState)
+
+        for exception in (TardisAuthError, TardisTimeout, TardisQuotaExceeded, TardisResourceStatusUpdateFailed):
+            self.drone.state.return_value = RequestState()
+            self.drone.site_agent.deploy_resource.side_effect = exception()
+            run_async(self.drone.state.return_value.run, self.drone)
+            self.assertIsInstance(self.drone.state, DownState)
+
+        self.drone.site_agent.deploy_resource.side_effect = None
+
+        self.run_side_effects(RequestState(), self.drone.site_agent.deploy_resource,
+                              (TardisDroneCrashed,),
+                              CleanupState)
+
+    def test_booting_state(self):
+        matrix = [(ResourceStatus.Booting, None, BootingState),
+                  (ResourceStatus.Running, None, IntegrateState),
+                  (ResourceStatus.Deleted, None, DownState),
+                  (ResourceStatus.Stopped, None, CleanupState)]
+
+        self.run_the_matrix(matrix, initial_state=BootingState)
+
+    def test_integrate_state(self):
+        self.drone.state.return_value = IntegrateState
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, IntegratingState)
+        self.drone.batch_system_agent.integrate_machine.assert_called_with(dns_name='test-923ABF')
+
+    def test_integrating_state(self):
+
+        matrix = [(ResourceStatus.Running, MachineStatus.NotAvailable, IntegratingState),
+                  (ResourceStatus.Running, MachineStatus.Available, AvailableState),
+                  (ResourceStatus.Running, MachineStatus.Draining, DrainingState),
+                  (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
+                  (ResourceStatus.Booting, MachineStatus.NotAvailable, BootingState),
+                  (ResourceStatus.Booting, MachineStatus.Available, BootingState),
+                  (ResourceStatus.Booting, MachineStatus.Drained, BootingState),
+                  (ResourceStatus.Booting, MachineStatus.Draining, BootingState),
+                  (ResourceStatus.Deleted, MachineStatus.NotAvailable, DownState),
+                  (ResourceStatus.Stopped, MachineStatus.NotAvailable, CleanupState)]
+
+        self.run_the_matrix(matrix, initial_state=IntegratingState)
+
+    def test_available_state(self):
+        matrix = [(ResourceStatus.Running, MachineStatus.Available, AvailableState),
+                  (ResourceStatus.Running, MachineStatus.NotAvailable, IntegratingState),
+                  (ResourceStatus.Running, MachineStatus.Draining, DrainingState),
+                  (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
+                  (ResourceStatus.Booting, MachineStatus.NotAvailable, BootingState),
+                  (ResourceStatus.Deleted, MachineStatus.NotAvailable, DownState),
+                  (ResourceStatus.Stopped, MachineStatus.NotAvailable, CleanupState)]
+
+        self.run_the_matrix(matrix, initial_state=AvailableState)
+
+    def test_drain_state(self):
+        self.drone.state.return_value = DrainState
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, DrainingState)
+        self.drone.batch_system_agent.drain_machine.assert_called_with(dns_name='test-923ABF')
+
+    def test_draining_state(self):
+        matrix = [(ResourceStatus.Running, MachineStatus.Draining, DrainingState),
+                  (ResourceStatus.Running, MachineStatus.Available, DrainingState),
+                  (ResourceStatus.Running, MachineStatus.Drained, DisintegrateState),
+                  (ResourceStatus.Running, MachineStatus.NotAvailable, ShutDownState),
+                  (ResourceStatus.Deleted, MachineStatus.NotAvailable, DownState),
+                  (ResourceStatus.Stopped, MachineStatus.NotAvailable, CleanupState)]
+
+        self.run_the_matrix(matrix, initial_state=DrainingState)
+
+    def test_disintegrate_state(self):
+        self.drone.state.return_value = DisintegrateState
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, ShutDownState)
+        self.drone.batch_system_agent.disintegrate_machine.assert_called_with(dns_name='test-923ABF')
+
+    def test_shutdown_state(self):
+        matrix = [(ResourceStatus.Running, None, ShuttingDownState),
+                  (ResourceStatus.Stopped, None, CleanupState),
+                  (ResourceStatus.Deleted, None, DownState)]
+
+        self.run_the_matrix(matrix, initial_state=ShutDownState)
+
+        for exception in (TardisAuthError, TardisTimeout, TardisResourceStatusUpdateFailed):
+            self.drone.state.return_value = ShutDownState()
+            self.drone.site_agent.resource_status.side_effect = exception()
+            run_async(self.drone.state.return_value.run, self.drone)
+            self.assertIsInstance(self.drone.state, ShutDownState)
+
+            self.drone.state.return_value = ShutDownState()
+            self.drone.site_agent.resource_status.side_effect = TardisDroneCrashed()
+            run_async(self.drone.state.return_value.run, self.drone)
+            self.assertIsInstance(self.drone.state, CleanupState)
+
+            self.drone.site_agent.resource_status.side_effect = None
+
+    def test_shutting_down_state(self):
+        matrix = [(ResourceStatus.Running, None, ShuttingDownState),
+                  (ResourceStatus.Stopped, None, CleanupState),
+                  (ResourceStatus.Deleted, None, DownState)]
+
+        self.run_the_matrix(matrix, initial_state=ShuttingDownState)
+
+    def test_cleanup_state(self):
+        self.drone.state.return_value = CleanupState()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, DownState)
+        self.drone.site_agent.terminate_resource.assert_called_with(self.drone.resource_attributes)
+
+        self.drone.state.return_value = CleanupState()
+        self.drone.site_agent.terminate_resource.side_effect = TardisDroneCrashed()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, DownState)
+
+        self.drone.state.return_value = CleanupState()
+        self.drone.site_agent.terminate_resource.side_effect = TardisResourceStatusUpdateFailed()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertIsInstance(self.drone.state, CleanupState)
+
+        self.drone.site_agent.terminate_resource.side_effect = None
+
+    def test_down_state(self):
+        self.drone.state.return_value = DownState()
+        run_async(self.drone.state.return_value.run, self.drone)
+        self.assertEqual(self.drone.demand, 0.0)

--- a/tests/utilities_t/test_pipeline.py
+++ b/tests/utilities_t/test_pipeline.py
@@ -1,0 +1,37 @@
+from tardis.utilities.pipeline import PipelineProcessor
+from tardis.utilities.pipeline import StopProcessing
+from ..utilities.utilities import run_async
+
+from unittest import TestCase
+
+
+class TestPipelineProcessor(TestCase):
+    def setUp(self):
+        async def test_update(pipeline_input, drone):
+            self.assertEqual(pipeline_input, 10)
+            self.assertEqual(drone, "drone_place_holder")
+            return 1
+
+        self.pipeline_processor = PipelineProcessor([test_update])
+
+    def test_pipeline_processor(self):
+        self.assertEqual(run_async(self.pipeline_processor.run_pipeline, pipeline_input=10,
+                                   drone="drone_place_holder"), 1)
+
+    def test_add_function(self):
+        async def test_add(pipeline_input, drone):
+            self.assertEqual(pipeline_input, 1)
+            self.assertEqual(drone, "drone_place_holder")
+            return 2
+        self.pipeline_processor.add_to_pipeline(test_add)
+        self.assertEqual(run_async(self.pipeline_processor.run_pipeline, pipeline_input=10,
+                                   drone="drone_place_holder"), 2)
+
+    def test_stop_processing(self):
+        def test_stop_processing(pipeline_input, drone):
+            self.assertEqual(pipeline_input, 10)
+            self.assertEqual(drone, "drone_place_holder")
+            raise StopProcessing(last_result=99)
+
+        pipeline_processor = PipelineProcessor([test_stop_processing])
+        self.assertEqual(run_async(pipeline_processor.run_pipeline, pipeline_input=10, drone="drone_place_holder"), 99)


### PR DESCRIPTION
This pull request adds:

- Pipeline processor
- Configures logger for sqliteregistry
- Refactoring of restoring drones from registry
- Support tag for Python3.7 to setup.py
- Change repository url in setup.py
- Refactoring of dronestate and their transitions
- Fixes a bug in the OpenStack adapter. Mutable configuration dict in now copied, so that each simultanously deployed instance has a different dns_name. 