### PR TITLE
Add htcondor site adapter

### DIFF
--- a/tardis/adapters/batchsystems/htcondor.py
+++ b/tardis/adapters/batchsystems/htcondor.py
@@ -11,7 +11,7 @@ import logging
 
 
 async def htcondor_status_updater():
-    attributes = dict(Machine='Machine', State='State', Activity='Activity')
+    attributes = dict(Machine='Machine', State='State', Activity='Activity', TardisDroneUuid='TardisDroneUuid')
     # Escape htcondor expressions and add them to attributes
     attributes.update({key: quote(value) for key, value in Configuration().BatchSystem.ratios.items()})
     attributes_string = " ".join(attributes.values())
@@ -24,7 +24,8 @@ async def htcondor_status_updater():
         condor_status = await async_run_command(cmd)
         for row in htcondor_csv_parser(htcondor_input=condor_status, fieldnames=tuple(attributes.keys()),
                                        delimiter='\t', replacements=dict(undefined=None)):
-            htcondor_status[row['Machine'].split('.')[0]] = row
+            status_key = row['TardisDroneUuid'] or row['Machine'].split('.')[0]
+            htcondor_status[status_key] = row
 
     except AsyncRunCommandFailure as ex:
         logging.error("condor_status could not be executed!")

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,6 +1,9 @@
 from ...configuration.configuration import Configuration
+from ...exceptions.executorexceptions import CommandExecutionFailure
 from ...exceptions.tardisexceptions import TardisError
+from ...exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from ...interfaces.siteadapter import SiteAdapter
+from ...interfaces.siteadapter import ResourceStatus
 from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
 from ...utilities.staticmapping import StaticMapping
@@ -9,7 +12,10 @@ from ...utilities.executors.shellexecutor import ShellExecutor
 from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
+from io import StringIO
 
+import csv
+import logging
 import re
 
 
@@ -19,10 +25,17 @@ async def htcondor_queue_updater(executor):
     queue_command = f"condor_q -af:t {attributes_string}"
 
     htcondor_queue = {}
-
-    executor.run_command(queue_command)
-
-    return htcondor_queue
+    try:
+        condor_queue = await executor.run_command(queue_command)
+    except CommandExecutionFailure as cf:
+        logging.error(f"htcondor_queue_update failed: {cf}")
+        raise
+    else:
+        with StringIO(condor_queue.stdout) as csv_input:
+            cvs_reader = csv.DictReader(csv_input, fieldnames=tuple(attributes.keys()), delimiter='\t')
+            for row in cvs_reader:
+                htcondor_queue[int(row['ClusterId'])] = row
+        return htcondor_queue
 
 
 class HTCondorSiteAdapter(SiteAdapter):
@@ -32,8 +45,21 @@ class HTCondorSiteAdapter(SiteAdapter):
         self._site_name = site_name
         self._executor = getattr(self.configuration, 'executor', ShellExecutor())
 
-        key_translator = StaticMapping(resource_id='cluster_id', created='created', updated='updated')
-        translator_functions = StaticMapping(cluster_id=lambda x: int(x))
+        key_translator = StaticMapping(resource_id='ClusterId', resource_status='JobStatus',
+                                       created='created', updated='updated')
+
+        # HTCondor uses digits to indicate job states and digit as variable names are not allowed in Python, therefore
+        # the trick using an expanded dictionary is necessary. Somehow ugly.
+        translator_functions = StaticMapping(ClusterId=lambda x: int(x),
+                                             JobStatus=lambda x,
+                                             translator=StaticMapping(**{'0': ResourceStatus.Error,
+                                                                         '1': ResourceStatus.Booting,
+                                                                         '2': ResourceStatus.Running,
+                                                                         '3': ResourceStatus.Stopped,
+                                                                         '4': ResourceStatus.Deleted,
+                                                                         '5': ResourceStatus.Error,
+                                                                         '6': ResourceStatus.Error}):
+                                             translator[x])
 
         self.handle_response = partial(self.handle_response, key_translator=key_translator,
                                        translator_functions=translator_functions)
@@ -44,7 +70,7 @@ class HTCondorSiteAdapter(SiteAdapter):
     async def deploy_resource(self, resource_attributes):
         submit_command = f"condor_submit {self.configuration.jdl}"
         response = await self._executor.run_command(submit_command)
-        pattern = re.compile(r"^.*?(?P<jobs>\d+).*?(?P<cluster_id>\d+).$", flags=re.MULTILINE)
+        pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())
         now = datetime.now()
         response.update(AttributeDict(created=now, updated=now))
@@ -65,9 +91,16 @@ class HTCondorSiteAdapter(SiteAdapter):
     async def resource_status(self, resource_attributes):
         await self._htcondor_queue.update_status()
         try:
-            self._htcondor_queue[resource_attributes.resource_id]
+            resource_status = self._htcondor_queue[resource_attributes.resource_id]
         except KeyError:
-            pass
+            # In case the created timestamp is after last update timestamp of the asynccachemap,
+            # no decision about the current state can be given, since map is updated asynchronously.
+            if (self._htcondor_queue.last_update - resource_attributes.created).total_seconds() < 0:
+                raise TardisResourceStatusUpdateFailed
+            else:
+                return AttributeDict(resource_status=ResourceStatus.Deleted)
+        else:
+            return self.handle_response(resource_status)
 
     async def stop_resource(self, resource_attributes):
         """"Stopping machines is not supported in HTCondor, therefore terminate is called!"""
@@ -82,5 +115,7 @@ class HTCondorSiteAdapter(SiteAdapter):
     def handle_exceptions(self):
         try:
             yield
+        except TardisResourceStatusUpdateFailed:
+            raise
         except Exception as ex:
             raise TardisError from ex

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -8,13 +8,12 @@ from ...utilities.asynccachemap import AsyncCacheMap
 from ...utilities.attributedict import AttributeDict
 from ...utilities.staticmapping import StaticMapping
 from ...utilities.executors.shellexecutor import ShellExecutor
+from ...utilities.utils import htcondor_csv_parser
 
 from contextlib import contextmanager
 from datetime import datetime
 from functools import partial
-from io import StringIO
 
-import csv
 import logging
 import re
 
@@ -31,10 +30,9 @@ async def htcondor_queue_updater(executor):
         logging.error(f"htcondor_queue_update failed: {cf}")
         raise
     else:
-        with StringIO(condor_queue.stdout) as csv_input:
-            cvs_reader = csv.DictReader(csv_input, fieldnames=tuple(attributes.keys()), delimiter='\t')
-            for row in cvs_reader:
-                htcondor_queue[int(row['ClusterId'])] = row
+        for row in htcondor_csv_parser(htcondor_input=condor_queue.stdout, fieldnames=tuple(attributes.keys()),
+                                       delimiter='\t', replacements=dict(undefined=None)):
+            htcondor_queue[int(row['ClusterId'])] = row
         return htcondor_queue
 
 

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,9 +1,28 @@
 from ...configuration.configuration import Configuration
 from ...exceptions.tardisexceptions import TardisError
 from ...interfaces.siteadapter import SiteAdapter
+from ...utilities.asynccachemap import AsyncCacheMap
+from ...utilities.attributedict import AttributeDict
+from ...utilities.staticmapping import StaticMapping
 from ...utilities.executors.shellexecutor import ShellExecutor
 
 from contextlib import contextmanager
+from datetime import datetime
+from functools import partial
+
+import re
+
+
+async def htcondor_queue_updater(executor):
+    attributes = dict(Owner="Owner", JobStatus="JobStatus", ClusterId="ClusterId", ProcId="ProcId")
+    attributes_string = " ".join(attributes.values())
+    queue_command = f"condor_q -af:t {attributes_string}"
+
+    htcondor_queue = {}
+
+    executor.run_command(queue_command)
+
+    return htcondor_queue
 
 
 class HTCondorSiteAdapter(SiteAdapter):
@@ -13,8 +32,23 @@ class HTCondorSiteAdapter(SiteAdapter):
         self._site_name = site_name
         self._executor = getattr(self.configuration, 'executor', ShellExecutor())
 
+        key_translator = StaticMapping(resource_id='cluster_id', created='created', updated='updated')
+        translator_functions = StaticMapping(cluster_id=lambda x: int(x))
+
+        self.handle_response = partial(self.handle_response, key_translator=key_translator,
+                                       translator_functions=translator_functions)
+
+        self._htcondor_queue = AsyncCacheMap(update_coroutine=partial(htcondor_queue_updater, self._executor),
+                                             max_age=self.configuration.max_age * 60)
+
     async def deploy_resource(self, resource_attributes):
-        pass
+        submit_command = f"condor_submit {self.configuration.jdl}"
+        response = await self._executor.run_command(submit_command)
+        pattern = re.compile(r"^.*?(?P<jobs>\d+).*?(?P<cluster_id>\d+).$", flags=re.MULTILINE)
+        response = AttributeDict(pattern.search(response.stdout).groupdict())
+        now = datetime.now()
+        response.update(AttributeDict(created=now, updated=now))
+        return self.handle_response(response)
 
     @property
     def machine_meta_data(self):
@@ -29,13 +63,20 @@ class HTCondorSiteAdapter(SiteAdapter):
         return self._site_name
 
     async def resource_status(self, resource_attributes):
-        pass
+        await self._htcondor_queue.update_status()
+        try:
+            self._htcondor_queue[resource_attributes.resource_id]
+        except KeyError:
+            pass
 
     async def stop_resource(self, resource_attributes):
-        pass
+        """"Stopping machines is not supported in HTCondor, therefore terminate is called!"""
+        return await self.terminate_resource(resource_attributes)
 
     async def terminate_resource(self, resource_attributes):
-        pass
+        terminate_command = f"condor_rm {resource_attributes.resource_id}"
+        response = self._executor.run_command(terminate_command)
+        return response
 
     @contextmanager
     def handle_exceptions(self):

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -58,8 +58,7 @@ class HTCondorAdapter(SiteAdapter):
         # HTCondor uses digits to indicate job states and digit as variable names are not allowed in Python, therefore
         # the trick using an expanded htcondor_status_code dictionary is necessary. Somehow ugly.
         translator_functions = StaticMapping(ClusterId=lambda x: int(x),
-                                             JobStatus=lambda x,
-                                             translator=StaticMapping(**htcondor_status_codes):
+                                             JobStatus=lambda x, translator=StaticMapping(**htcondor_status_codes):
                                              translator[x])
 
         self.handle_response = partial(self.handle_response, key_translator=key_translator,
@@ -70,7 +69,8 @@ class HTCondorAdapter(SiteAdapter):
 
     async def deploy_resource(self, resource_attributes):
         submit_jdl = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
-        submit_command = f"condor_submit {submit_jdl}"
+        submit_command = \
+            f'condor_submit -append "environment = TardisDroneUuid={resource_attributes.drone_uuid}" {submit_jdl}'
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -1,0 +1,45 @@
+from ...configuration.configuration import Configuration
+from ...exceptions.tardisexceptions import TardisError
+from ...interfaces.siteadapter import SiteAdapter
+from ...utilities.executors.shellexecutor import ShellExecutor
+
+from contextlib import contextmanager
+
+
+class HTCondorSiteAdapter(SiteAdapter):
+    def __init__(self, machine_type, site_name):
+        self.configuration = getattr(Configuration(), site_name)
+        self._machine_type = machine_type
+        self._site_name = site_name
+        self._executor = getattr(self.configuration, 'executor', ShellExecutor())
+
+    async def deploy_resource(self, resource_attributes):
+        pass
+
+    @property
+    def machine_meta_data(self):
+        return self.configuration.MachineMetaData[self._machine_type]
+
+    @property
+    def machine_type(self):
+        return self._machine_type
+
+    @property
+    def site_name(self):
+        return self._site_name
+
+    async def resource_status(self, resource_attributes):
+        pass
+
+    async def stop_resource(self, resource_attributes):
+        pass
+
+    async def terminate_resource(self, resource_attributes):
+        pass
+
+    @contextmanager
+    def handle_exceptions(self):
+        try:
+            yield
+        except Exception as ex:
+            raise TardisError from ex

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -71,7 +71,8 @@ class HTCondorSiteAdapter(SiteAdapter):
                                              max_age=self.configuration.max_age * 60)
 
     async def deploy_resource(self, resource_attributes):
-        submit_command = f"condor_submit {self.configuration.jdl}"
+        submit_jdl = self.configuration.MachineTypeConfiguration[self._machine_type].jdl
+        submit_command = f"condor_submit {submit_jdl}"
         response = await self._executor.run_command(submit_command)
         pattern = re.compile(r"^.*?(?P<Jobs>\d+).*?(?P<ClusterId>\d+).$", flags=re.MULTILINE)
         response = AttributeDict(pattern.search(response.stdout).groupdict())

--- a/tardis/adapters/sites/htcondor.py
+++ b/tardis/adapters/sites/htcondor.py
@@ -47,7 +47,7 @@ htcondor_status_codes = {'0': ResourceStatus.Error,
                          '6': ResourceStatus.Error}
 
 
-class HTCondorSiteAdapter(SiteAdapter):
+class HTCondorAdapter(SiteAdapter):
     def __init__(self, machine_type, site_name):
         self.configuration = getattr(Configuration(), site_name)
         self._machine_type = machine_type

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -107,7 +107,7 @@ class MoabAdapter(SiteAdapter):
         try:
             resource_status = self._moab_status[str(resource_attributes.remote_resource_uuid)]
         except KeyError:
-            if (self._moab_status._last_update - resource_attributes.created) < 0:
+            if (self._moab_status.last_update - resource_attributes.created).total_seconds() < 0:
                 raise TardisResourceStatusUpdateFailed
             else:
                 resource_status = {"JobID": resource_attributes.remote_resource_uuid, "State": "Completed"}

--- a/tardis/utilities/asynccachemap.py
+++ b/tardis/utilities/asynccachemap.py
@@ -1,7 +1,9 @@
+from ..exceptions.executorexceptions import CommandExecutionFailure
 from collections.abc import Mapping
 from time import time
 
 import asyncio
+import logging
 import json
 
 
@@ -28,8 +30,10 @@ class AsyncCacheMap(Mapping):
             if (current_time - self._last_update) > self._max_age:
                 try:
                     data = await self._update_coroutine()
-                except json.decoder.JSONDecodeError:
-                    pass
+                except json.decoder.JSONDecodeError as je:
+                    logging.error(f"AsyncMap update_status failed: Could not decode json {je}")
+                except CommandExecutionFailure as cf:
+                    logging.error(f"AsyncMap update_status failed: {cf}")
                 else:
                     self._data = data
                 self._last_update = current_time

--- a/tardis/utilities/utils.py
+++ b/tardis/utilities/utils.py
@@ -2,6 +2,10 @@ from .executors.shellexecutor import ShellExecutor
 from ..exceptions.tardisexceptions import AsyncRunCommandFailure
 from ..exceptions.executorexceptions import CommandExecutionFailure
 
+from io import StringIO
+
+import csv
+
 
 async def async_run_command(cmd, shell_executor=ShellExecutor()):
     try:
@@ -16,3 +20,12 @@ async def async_run_command(cmd, shell_executor=ShellExecutor()):
         raise AsyncRunCommandFailure(message=ef.stdout, error_code=ef.exit_code, error_message=ef.stderr) from ef
     else:
         return response.stdout
+
+
+def htcondor_csv_parser(htcondor_input, fieldnames, delimiter='\t', replacements=None):
+    replacements = replacements or {}
+    with StringIO(htcondor_input) as csv_input:
+        cvs_reader = csv.DictReader(csv_input, fieldnames=fieldnames, delimiter=delimiter)
+        for row in cvs_reader:
+            yield {key: value if value not in replacements.keys() else replacements[value]
+                   for key, value in row.items()}

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -1,13 +1,42 @@
 from tardis.adapters.sites.htcondor import HTCondorSiteAdapter
 from tardis.exceptions.tardisexceptions import TardisError
 from tardis.utilities.attributedict import AttributeDict
+from ...utilities.utilities import async_return
+from ...utilities.utilities import mock_executor_run_command
 from ...utilities.utilities import run_async
 
+from datetime import datetime
+from datetime import timedelta
 from unittest import TestCase
 from unittest.mock import patch
 
+CONDOR_SUBMIT_OUTPUT = """Submitting job(s).
+1 job(s) submitted to cluster 1351043."""
+
+CONDOR_Q_OUTPUT_IDLE = """"
+
+-- Schedd: test.etp.kit.edu : <129.11.111.111:9618?... @ 03/12/19 09:16:58
+OWNER   BATCH_NAME      SUBMITTED   DONE   RUN    IDLE  TOTAL JOB_IDS
+test CMD: test.sh   3/12 09:15      _      _      1      1 1351043.0
+
+1 jobs; 0 completed, 0 removed, 1 idle, 0 running, 0 held, 0 suspended"""
+
+CONDOR_Q_OUTPUT_RUN = """
+
+
+-- Schedd: test.etp.kit.edu : <129.11.111.111:9618?... @ 03/12/19 09:23:09
+OWNER   BATCH_NAME      SUBMITTED   DONE   RUN    IDLE  TOTAL JOB_IDS
+test CMD: test.sh   3/12 09:15      _      1      _      1 1351043.0
+
+1 jobs; 0 completed, 0 removed, 0 idle, 1 running, 0 held, 0 suspended"""
+
+CONDOR_RM_OUTPUT = """"All jobs in cluster 1351043 have been marked for removal"""
+
 
 class TestHTCondorSiteAdapter(TestCase):
+    mock_config_patcher = None
+    mock_executor_patcher = None
+
     @classmethod
     def setUpClass(cls):
         cls.mock_config_patcher = patch('tardis.adapters.sites.htcondor.Configuration')
@@ -26,6 +55,8 @@ class TestHTCondorSiteAdapter(TestCase):
         test_site_config.MachineMetaData = self.machine_meta_data
         test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         test_site_config.executor = self.mock_executor.return_value
+        test_site_config.jdl = 'submit.jdl'
+        test_site_config.max_age = 10
 
         self.adapter = HTCondorSiteAdapter(machine_type='test2large', site_name='TestSite')
 
@@ -37,8 +68,15 @@ class TestHTCondorSiteAdapter(TestCase):
     def machine_type_configuration(self):
         return AttributeDict(test2large=AttributeDict())
 
+    @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
-        run_async(self.adapter.deploy_resource, AttributeDict())
+        response = run_async(self.adapter.deploy_resource, AttributeDict())
+        self.assertEqual(response.resource_id, 1351043)
+        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
+        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
+
+        self.mock_executor.return_value.run_command.assert_called_with('condor_submit submit.jdl')
+        self.mock_executor.reset()
 
     def test_machine_meta_data(self):
         self.assertEqual(self.adapter.machine_meta_data, self.machine_meta_data.test2large)
@@ -50,19 +88,19 @@ class TestHTCondorSiteAdapter(TestCase):
         self.assertEqual(self.adapter.site_name, 'TestSite')
 
     def test_resource_status(self):
-        run_async(self.adapter.resource_status, AttributeDict())
+        run_async(self.adapter.resource_status, AttributeDict(resource_id=1351043))
 
     def test_stop_resource(self):
-        run_async(self.adapter.stop_resource, AttributeDict())
+        run_async(self.adapter.stop_resource, AttributeDict(resource_id=1351043))
 
     def test_terminate_resource(self):
-        run_async(self.adapter.terminate_resource, AttributeDict())
+        run_async(self.adapter.terminate_resource, AttributeDict(resource_id=1351043))
 
     def test_exception_handling(self):
-        def test_exception_handling(to_raise, to_catch):
-            with self.assertRaises(to_catch):
+        def test_exception_handling(raise_it, catch_it):
+            with self.assertRaises(catch_it):
                 with self.adapter.handle_exceptions():
-                    raise to_raise
+                    raise raise_it
 
         matrix = [(Exception, TardisError)]
 

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -50,7 +50,6 @@ class TestHTCondorSiteAdapter(TestCase):
         test_site_config.MachineMetaData = self.machine_meta_data
         test_site_config.MachineTypeConfiguration = self.machine_type_configuration
         test_site_config.executor = self.mock_executor.return_value
-        test_site_config.jdl = 'submit.jdl'
         test_site_config.max_age = 10
 
         self.adapter = HTCondorSiteAdapter(machine_type='test2large', site_name='TestSite')
@@ -61,7 +60,7 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @property
     def machine_type_configuration(self):
-        return AttributeDict(test2large=AttributeDict())
+        return AttributeDict(test2large=AttributeDict(jdl='submit.jdl'))
 
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -1,4 +1,4 @@
-from tardis.adapters.sites.htcondor import HTCondorSiteAdapter
+from tardis.adapters.sites.htcondor import HTCondorAdapter
 from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.exceptions.tardisexceptions import TardisError
 from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
@@ -52,7 +52,7 @@ class TestHTCondorSiteAdapter(TestCase):
         test_site_config.executor = self.mock_executor.return_value
         test_site_config.max_age = 10
 
-        self.adapter = HTCondorSiteAdapter(machine_type='test2large', site_name='TestSite')
+        self.adapter = HTCondorAdapter(machine_type='test2large', site_name='TestSite')
 
     @property
     def machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -1,0 +1,70 @@
+from tardis.adapters.sites.htcondor import HTCondorSiteAdapter
+from tardis.exceptions.tardisexceptions import TardisError
+from tardis.utilities.attributedict import AttributeDict
+from ...utilities.utilities import run_async
+
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestHTCondorSiteAdapter(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mock_config_patcher = patch('tardis.adapters.sites.htcondor.Configuration')
+        cls.mock_config = cls.mock_config_patcher.start()
+        cls.mock_executor_patcher = patch('tardis.adapters.sites.htcondor.ShellExecutor')
+        cls.mock_executor = cls.mock_executor_patcher.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mock_config_patcher.stop()
+        cls.mock_executor_patcher.stop()
+
+    def setUp(self):
+        config = self.mock_config.return_value
+        test_site_config = config.TestSite
+        test_site_config.MachineMetaData = self.machine_meta_data
+        test_site_config.MachineTypeConfiguration = self.machine_type_configuration
+        test_site_config.executor = self.mock_executor.return_value
+
+        self.adapter = HTCondorSiteAdapter(machine_type='test2large', site_name='TestSite')
+
+    @property
+    def machine_meta_data(self):
+        return AttributeDict(test2large=AttributeDict(Cores=8, Memory='32'))
+
+    @property
+    def machine_type_configuration(self):
+        return AttributeDict(test2large=AttributeDict())
+
+    def test_deploy_resource(self):
+        run_async(self.adapter.deploy_resource, AttributeDict())
+
+    def test_machine_meta_data(self):
+        self.assertEqual(self.adapter.machine_meta_data, self.machine_meta_data.test2large)
+
+    def test_machine_type(self):
+        self.assertEqual(self.adapter.machine_type, 'test2large')
+
+    def test_site_name(self):
+        self.assertEqual(self.adapter.site_name, 'TestSite')
+
+    def test_resource_status(self):
+        run_async(self.adapter.resource_status, AttributeDict())
+
+    def test_stop_resource(self):
+        run_async(self.adapter.stop_resource, AttributeDict())
+
+    def test_terminate_resource(self):
+        run_async(self.adapter.terminate_resource, AttributeDict())
+
+    def test_exception_handling(self):
+        def test_exception_handling(to_raise, to_catch):
+            with self.assertRaises(to_catch):
+                with self.adapter.handle_exceptions():
+                    raise to_raise
+
+        matrix = [(Exception, TardisError)]
+
+        for to_raise, to_catch in matrix:
+            test_exception_handling(to_raise, to_catch)

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -17,15 +17,15 @@ import logging
 CONDOR_SUBMIT_OUTPUT = """Submitting job(s).
 1 job(s) submitted to cluster 1351043."""
 
-CONDOR_Q_OUTPUT_UNEXANPANDED = "giffels\t0\t1351043\t0"
-CONDOR_Q_OUTPUT_IDLE = "giffels\t1\t1351043\t0"
-CONDOR_Q_OUTPUT_RUN = "giffels\t2\t1351043\t0"
-CONDOR_Q_OUTPUT_REMOVED = "giffels\t3\t1351043\t0"
-CONDOR_Q_OUTPUT_COMPLETED = "giffels\t4\t1351043\t0"
-CONDOR_Q_OUTPUT_HELD = "giffels\t5\t1351043\t0"
-CONDOR_Q_OUTPUT_SUBMISSION_ERR = "giffels\t6\t1351043\t0"
+CONDOR_Q_OUTPUT_UNEXANPANDED = "test\t0\t1351043\t0"
+CONDOR_Q_OUTPUT_IDLE = "test\t1\t1351043\t0"
+CONDOR_Q_OUTPUT_RUN = "test\t2\t1351043\t0"
+CONDOR_Q_OUTPUT_REMOVED = "test\t3\t1351043\t0"
+CONDOR_Q_OUTPUT_COMPLETED = "test\t4\t1351043\t0"
+CONDOR_Q_OUTPUT_HELD = "test\t5\t1351043\t0"
+CONDOR_Q_OUTPUT_SUBMISSION_ERR = "test\t6\t1351043\t0"
 
-CONDOR_RM_OUTPUT = """"All jobs in cluster 1351043 have been marked for removal"""
+CONDOR_RM_OUTPUT = """All jobs in cluster 1351043 have been marked for removal"""
 
 
 class TestHTCondorSiteAdapter(TestCase):
@@ -133,11 +133,19 @@ class TestHTCondorSiteAdapter(TestCase):
                                                                              created=past_timestamp))
         self.assertEqual(response.resource_status, ResourceStatus.Deleted)
 
+    @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_stop_resource(self):
-        run_async(self.adapter.stop_resource, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.stop_resource, AttributeDict(resource_id=1351043))
+        self.assertEqual(response.resource_id, 1351043)
+        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
+        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
+    @mock_executor_run_command(stdout=CONDOR_RM_OUTPUT)
     def test_terminate_resource(self):
-        run_async(self.adapter.terminate_resource, AttributeDict(resource_id=1351043))
+        response = run_async(self.adapter.terminate_resource, AttributeDict(resource_id=1351043))
+        self.assertEqual(response.resource_id, 1351043)
+        self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
+        self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
     def test_exception_handling(self):
         def test_exception_handling(raise_it, catch_it):

--- a/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
+++ b/tests/adapters_t/sites_t/test_htcondorsiteadapter.py
@@ -64,13 +64,13 @@ class TestHTCondorSiteAdapter(TestCase):
 
     @mock_executor_run_command(stdout=CONDOR_SUBMIT_OUTPUT)
     def test_deploy_resource(self):
-        response = run_async(self.adapter.deploy_resource, AttributeDict(dns_name='test-123'))
+        response = run_async(self.adapter.deploy_resource, AttributeDict(drone_uuid='test-123'))
         self.assertEqual(response.resource_id, 1351043)
         self.assertFalse(response.created - datetime.now() > timedelta(seconds=1))
         self.assertFalse(response.updated - datetime.now() > timedelta(seconds=1))
 
         self.mock_executor.return_value.run_command.assert_called_with(
-            'condor_submit submit.jdl')
+            'condor_submit -append "environment = TardisDroneUuid=test-123" submit.jdl')
         self.mock_executor.reset()
 
     def test_machine_meta_data(self):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -216,22 +216,22 @@ class TestMoabAdapter(TestCase):
         # creation date to current date
         created_timestamp = datetime.now()
         new_timestamp = datetime.now() - timedelta(minutes=2)
-        self.moab_adapter._moab_status._last_update = new_timestamp.timestamp()
+        self.moab_adapter._moab_status._last_update = new_timestamp
         with self.assertRaises(TardisResourceStatusUpdateFailed):
             response = run_async(self.moab_adapter.resource_status,
                                  AttributeDict(resource_id=1351043, remote_resource_uuid=1351043,
                                                resource_state=ResourceStatus.Booting,
-                                               created=created_timestamp.timestamp()))
+                                               created=created_timestamp))
 
     def test_resource_status_raise_past(self):
         # Update interval is 10 minutes, so set last update back by 11 minutes in order to execute sacct command and
         # creation date to 12 minutes ago
         past_timestamp = datetime.now() - timedelta(minutes=12)
         new_timestamp = datetime.now() - timedelta(minutes=11)
-        self.moab_adapter._moab_status._last_update = new_timestamp.timestamp()
+        self.moab_adapter._moab_status._last_update = new_timestamp
         response = run_async(self.moab_adapter.resource_status, AttributeDict(resource_id=1390065,
                                                                               remote_resource_uuid=1351043,
-                                                                              created=past_timestamp.timestamp()))
+                                                                              created=past_timestamp))
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     def test_exception_handling(self):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -6,6 +6,7 @@ from tardis.exceptions.tardisexceptions import TardisResourceStatusUpdateFailed
 from tardis.interfaces.siteadapter import ResourceStatus
 from tardis.utilities.attributedict import AttributeDict
 from tests.utilities.utilities import async_return
+from tests.utilities.utilities import mock_executor_run_command
 from tests.utilities.utilities import run_async
 
 from unittest import TestCase
@@ -78,22 +79,6 @@ TEST_TERMINATE_DEAD_RESOURCE_RESPONSE = '''
 ERROR:  invalid job specified (4761849)
 
 '''
-
-
-def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):
-    def decorator(func):
-        def wrapper(self):
-            executor = self.mock_executor.return_value
-            executor.run_command.return_value = async_return(return_value=AttributeDict(stdout=stdout,
-                                                                                        stderr=stderr,
-                                                                                        exit_code=exit_code))
-            executor.run_command.side_effect = raise_exception
-            func(self)
-            executor.run_command.side_effect = None
-
-        return wrapper
-
-    return decorator
 
 
 class TestMoabAdapter(TestCase):

--- a/tests/adapters_t/sites_t/test_slurm.py
+++ b/tests/adapters_t/sites_t/test_slurm.py
@@ -189,22 +189,22 @@ class TestSlurmAdapter(TestCase):
         # creation date to current date
         created_timestamp = datetime.now()
         new_timestamp = datetime.now() - timedelta(minutes=2)
-        self.slurm_adapter._slurm_status._last_update = new_timestamp.timestamp()
+        self.slurm_adapter._slurm_status._last_update = new_timestamp
         with self.assertRaises(TardisResourceStatusUpdateFailed):
             response = run_async(self.slurm_adapter.resource_status,
                                  AttributeDict(resource_id=1351043, remote_resource_uuid=1351043,
                                                resource_state=ResourceStatus.Booting,
-                                               created=created_timestamp.timestamp()))
+                                               created=created_timestamp))
 
     def test_resource_status_raise_past(self):
         # Update interval is 10 minutes, so set last update back by 11 minutes in order to execute sacct command and
         # creation date to 12 minutes ago
         past_timestamp = datetime.now() - timedelta(minutes=12)
         new_timestamp = datetime.now() - timedelta(minutes=11)
-        self.slurm_adapter._slurm_status._last_update = new_timestamp.timestamp()
+        self.slurm_adapter._slurm_status._last_update = new_timestamp
         response = run_async(self.slurm_adapter.resource_status, AttributeDict(resource_id=1390065,
                                                                                remote_resource_uuid=1351043,
-                                                                               created=past_timestamp.timestamp()))
+                                                                               created=past_timestamp))
         self.assertEqual(response.resource_status, ResourceStatus.Stopped)
 
     def test_exception_handling(self):

--- a/tests/utilities/utilities.py
+++ b/tests/utilities/utilities.py
@@ -1,3 +1,4 @@
+from tardis.utilities.attributedict import AttributeDict
 import asyncio
 
 
@@ -5,6 +6,22 @@ def async_return(*args, return_value=None, **kwargs):
     f = asyncio.Future()
     f.set_result(return_value)
     return f
+
+
+def mock_executor_run_command(stdout, stderr="", exit_code=0, raise_exception=None):
+    def decorator(func):
+        def wrapper(self):
+            executor = self.mock_executor.return_value
+            executor.run_command.return_value = async_return(return_value=AttributeDict(stdout=stdout,
+                                                                                        stderr=stderr,
+                                                                                        exit_code=exit_code))
+            executor.run_command.side_effect = raise_exception
+            func(self)
+            executor.run_command.side_effect = None
+
+        return wrapper
+
+    return decorator
 
 
 def run_async(coroutine, *args, **kwargs):

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -4,6 +4,8 @@ from tardis.utilities.asynccachemap import AsyncCacheMap
 from ..utilities.utilities import run_async
 
 from json.decoder import JSONDecodeError
+from datetime import datetime
+from datetime import timedelta
 from unittest import TestCase
 
 import logging
@@ -55,3 +57,8 @@ class TestAsyncCacheMap(TestCase):
         with self.assertLogs(logging.getLogger(), logging.ERROR):
             run_async(self.json_failing_async_cache_map.update_status)
             self.assertEqual(len(self.json_failing_async_cache_map), 0)
+
+    def test_last_update(self):
+        self.assertEqual(self.async_cache_map.last_update, datetime.fromtimestamp(0))
+        run_async(self.async_cache_map.update_status)
+        self.assertTrue(datetime.now()-self.async_cache_map.last_update < timedelta(seconds=1))

--- a/tests/utilities_t/test_asynccachemap.py
+++ b/tests/utilities_t/test_asynccachemap.py
@@ -1,25 +1,32 @@
+from tardis.exceptions.executorexceptions import CommandExecutionFailure
 from tardis.utilities.asynccachemap import AsyncCacheMap
+
+from ..utilities.utilities import run_async
 
 from json.decoder import JSONDecodeError
 from unittest import TestCase
-import asyncio
+
+import logging
 
 
 class TestAsyncCacheMap(TestCase):
     def setUp(self):
         self.test_data = {'testA': 123, 'testB': 'Random String'}
         self.async_cache_map = AsyncCacheMap(update_coroutine=self.update_function)
-        self.failing_async_cache_map = AsyncCacheMap(update_coroutine=self.failing_update_function)
+        self.json_failing_async_cache_map = AsyncCacheMap(update_coroutine=self.json_failing_update_function)
+        self.command_failing_async_cache_map = AsyncCacheMap(update_coroutine=self.command_failing_update_function)
 
-    async def failing_update_function(self):
+    async def json_failing_update_function(self):
         raise JSONDecodeError(msg='Bla', doc='Blubb', pos=99)
+
+    async def command_failing_update_function(self):
+        raise CommandExecutionFailure(message='Failure', stdout='Failure', stderr='Failure', exit_code=2)
 
     async def update_function(self):
         return self.test_data
 
     def update_status(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.async_cache_map.update_status())
+        run_async(self.async_cache_map.update_status)
 
     def test_update_async_cache_map(self):
         self.update_status()
@@ -39,7 +46,12 @@ class TestAsyncCacheMap(TestCase):
         for key, value in self.async_cache_map.items():
             self.assertEqual(value, self.test_data.get(key))
 
-    def test_failing_update(self):
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.failing_async_cache_map.update_status())
-        self.assertEqual(len(self.failing_async_cache_map), 0)
+    def test_json_failing_update(self):
+        with self.assertLogs(logging.getLogger(), logging.ERROR):
+            run_async(self.json_failing_async_cache_map.update_status)
+            self.assertEqual(len(self.json_failing_async_cache_map), 0)
+
+    def test_command_failing_update(self):
+        with self.assertLogs(logging.getLogger(), logging.ERROR):
+            run_async(self.json_failing_async_cache_map.update_status)
+            self.assertEqual(len(self.json_failing_async_cache_map), 0)

--- a/tests/utilities_t/test_utils.py
+++ b/tests/utilities_t/test_utils.py
@@ -1,18 +1,40 @@
 from tardis.utilities.utils import async_run_command
+from tardis.utilities.utils import htcondor_csv_parser
 from tardis.exceptions.tardisexceptions import AsyncRunCommandFailure
 
+from ..utilities.utilities import run_async
+
 from unittest import TestCase
-import asyncio
 
 
 class TestAsyncRunCommand(TestCase):
     def test_async_run_command(self):
-        loop = asyncio.get_event_loop()
-
-        loop.run_until_complete(async_run_command('exit 0'))
-        loop.run_until_complete(async_run_command('exit 255'))
+        run_async(async_run_command, 'exit 0')
+        run_async(async_run_command,'exit 255')
 
         with self.assertRaises(AsyncRunCommandFailure):
-            loop.run_until_complete(async_run_command('exit 1'))
+            run_async(async_run_command, 'exit 1')
 
-        self.assertEqual(loop.run_until_complete(async_run_command('echo "Test"')), "Test")
+        self.assertEqual(run_async(async_run_command, 'echo "Test"'), "Test")
+
+
+class TestHTCondorCSVParser(TestCase):
+    def test_htcondor_csv_parser(self):
+        htcondor_input = "\n".join(["exoscale-26d361290f\tUnclaimed\tIdle\t0.125\t0.125",
+                                    "test_replace\tOwner\tIdle\tundefined\tundefined"])
+
+        parsed_rows = htcondor_csv_parser(htcondor_input=htcondor_input,
+                                          fieldnames=('Machine', 'State', 'Activity', 'Test1', 'Test2'),
+                                          replacements=dict(undefined=None))
+
+        self.assertEqual(next(parsed_rows), dict(Machine="exoscale-26d361290f",
+                                                 State="Unclaimed",
+                                                 Activity="Idle",
+                                                 Test1="0.125",
+                                                 Test2="0.125"))
+
+        self.assertEqual(next(parsed_rows), dict(Machine="test_replace",
+                                                 State="Owner",
+                                                 Activity="Idle",
+                                                 Test1=None,
+                                                 Test2=None))


### PR DESCRIPTION
This pull request will add a htcondor site adapter in order to deploy drones on a htcondor batch system. By using the GridUniverse one can even deploy drones on any grid site using this adapter. HTCondor commands can be either executed locally or via ssh on a remote site. 