### PR TITLE
Enable yml.safe_load for PyYAML relase 5.1

### DIFF
--- a/tardis/configuration/configuration.py
+++ b/tardis/configuration/configuration.py
@@ -39,4 +39,4 @@ class Configuration(Borg):
         :type config_file: str
         """
         with open(config_file, 'r') as config_file:
-            self._shared_state.update(encode_user_data(convert_to_attribute_dict(yaml.load(config_file))))
+            self._shared_state.update(encode_user_data(convert_to_attribute_dict(yaml.safe_load(config_file))))

--- a/tardis/configuration/utilities.py
+++ b/tardis/configuration/utilities.py
@@ -14,6 +14,6 @@ def enable_yaml_load(tag):
                 parameters = loader.construct_sequence(node)
                 new_cls = cls(*parameters)
             return new_cls
-        yaml.add_constructor(tag, class_factory)
+        yaml.add_constructor(tag, class_factory, Loader=yaml.SafeLoader)
         return cls
     return yaml_load_decorator

--- a/tests/configuration_t/test_utilities.py
+++ b/tests/configuration_t/test_utilities.py
@@ -15,7 +15,7 @@ class TestDummy(object):
 class TestEnableYAMLLoad(TestCase):
     def test_enable_yaml_load(self):
         no_args_yml = """!TestDummy"""
-        instance = yaml.load(no_args_yml)
+        instance = yaml.safe_load(no_args_yml)
         self.assertEqual(instance.args, ())
         self.assertEqual(instance.kwargs, {})
 
@@ -23,7 +23,7 @@ class TestEnableYAMLLoad(TestCase):
         !TestDummy
         - test
         """
-        instance = yaml.load(args_yml)
+        instance = yaml.safe_load(args_yml)
         self.assertEqual(instance.args, ('test',))
         self.assertEqual(instance.kwargs, {})
 
@@ -31,6 +31,6 @@ class TestEnableYAMLLoad(TestCase):
         !TestDummy
         test: test
         """
-        instance = yaml.load(kwargs_yml)
+        instance = yaml.safe_load(kwargs_yml)
         self.assertEqual(instance.args, ())
         self.assertEqual(instance.kwargs, {'test': 'test'})

--- a/tests/utilities_t/executors_t/test_shellexecutor.py
+++ b/tests/utilities_t/executors_t/test_shellexecutor.py
@@ -24,7 +24,7 @@ class TestAsyncRunCommand(TestCase):
         self.assertEqual(run_async(self.executor.run_command, 'echo "Test" >>/dev/stderr').stderr, "Test")
 
     def test_construction_by_yaml(self):
-        executor = yaml.load("""
+        executor = yaml.safe_load("""
                       !ShellExecutor
         """)
         self.assertEqual(run_async(executor.run_command, 'exit 0').exit_code, 0)

--- a/tests/utilities_t/executors_t/test_sshexecutor.py
+++ b/tests/utilities_t/executors_t/test_sshexecutor.py
@@ -62,7 +62,7 @@ class TestSSHExecutor(TestCase):
         self.mock_asyncssh.reset_mock()
 
     def test_construction_by_yaml(self):
-        executor = yaml.load("""
+        executor = yaml.safe_load("""
                    !SSHExecutor
                    host: test_host
                    username: test


### PR DESCRIPTION
This pull request enables yml.safe_load of executors for PyYAML relase 5.1