### PR TITLE
Refactoring of the unique identifiers

### DIFF
--- a/tardis/adapters/batchsystems/fakebatchsystem.py
+++ b/tardis/adapters/batchsystems/fakebatchsystem.py
@@ -8,20 +8,20 @@ class FakeBatchSystemAdapter(BatchSystemAdapter):
         config = Configuration()
         self.dummy_config = config.BatchSystem
 
-    async def disintegrate_machine(self, dns_name):
+    async def disintegrate_machine(self, drone_uuid):
         return
 
-    async def drain_machine(self, dns_name):
+    async def drain_machine(self, drone_uuid):
         return
 
-    async def integrate_machine(self, dns_name):
+    async def integrate_machine(self, drone_uuid):
         return
 
-    async def get_allocation(self, dns_name):
+    async def get_allocation(self, drone_uuid):
         return self.dummy_config.allocation
 
-    async def get_machine_status(self, dns_name):
+    async def get_machine_status(self, drone_uuid):
         return getattr(MachineStatus, self.dummy_config.machine_status)
 
-    async def get_utilization(self, dns_name):
+    async def get_utilization(self, drone_uuid):
         return self.dummy_config.utilization

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -31,7 +31,7 @@ class CloudStackAdapter(SiteAdapter):
         self._machine_type = machine_type
         self._site_name = site_name
 
-        key_translator = StaticMapping(remote_resource_uuid='id', dns_name='name', resource_status='state')
+        key_translator = StaticMapping(remote_resource_uuid='id', drone_uuid='name', resource_status='state')
 
         translator_functions = StaticMapping(created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
                                              updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
@@ -46,7 +46,7 @@ class CloudStackAdapter(SiteAdapter):
                                        translator_functions=translator_functions)
 
     async def deploy_resource(self, resource_attributes):
-        response = await self.cloud_stack_client.deployVirtualMachine(name=resource_attributes.dns_name,
+        response = await self.cloud_stack_client.deployVirtualMachine(name=resource_attributes.drone_uuid,
                                                                       **self.configuration.MachineTypeConfiguration[
                                                                           self._machine_type])
         logging.debug(f"{self.site_name} deployVirtualMachine returned {response}")

--- a/tardis/adapters/sites/cloudstack.py
+++ b/tardis/adapters/sites/cloudstack.py
@@ -31,7 +31,7 @@ class CloudStackAdapter(SiteAdapter):
         self._machine_type = machine_type
         self._site_name = site_name
 
-        key_translator = StaticMapping(resource_id='id', dns_name='name', resource_status='state')
+        key_translator = StaticMapping(remote_resource_uuid='id', dns_name='name', resource_status='state')
 
         translator_functions = StaticMapping(created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
                                              updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%S%z"),
@@ -65,17 +65,17 @@ class CloudStackAdapter(SiteAdapter):
         return self._site_name
 
     async def resource_status(self, resource_attributes):
-        response = await self.cloud_stack_client.listVirtualMachines(id=resource_attributes.resource_id)
+        response = await self.cloud_stack_client.listVirtualMachines(id=resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} listVirtualMachines returned {response}")
         return self.handle_response(response['virtualmachine'][0])
 
     async def stop_resource(self, resource_attributes):
-        response = await self.cloud_stack_client.stopVirtualMachine(id=resource_attributes.resource_id)
+        response = await self.cloud_stack_client.stopVirtualMachine(id=resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} stopVirtualMachine returned {response}")
         return response
 
     async def terminate_resource(self, resource_attributes):
-        response = await self.cloud_stack_client.destroyVirtualMachine(id=resource_attributes.resource_id)
+        response = await self.cloud_stack_client.destroyVirtualMachine(id=resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} destroyVirtualMachine returned {response}")
         return response
 

--- a/tardis/adapters/sites/moab.py
+++ b/tardis/adapters/sites/moab.py
@@ -52,7 +52,7 @@ class MoabAdapter(SiteAdapter):
 
         remote_resource_uuid = int(result.stdout)
         resource_attributes.update(remote_resource_uuid=remote_resource_uuid, created=datetime.now(),
-                                   updated=datetime.now(), dns_name=self.dns_name(remote_resource_uuid),
+                                   updated=datetime.now(), drone_uuid=self.drone_uuid(remote_resource_uuid),
                                    resource_status=ResourceStatus.Booting)
         return resource_attributes
 

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -37,7 +37,7 @@ class OpenStackAdapter(SiteAdapter):
 
         self.nova = NovaClient(session=auth)
 
-        key_translator = StaticMapping(remote_resource_uuid='id', dns_name='name', resource_status='status')
+        key_translator = StaticMapping(remote_resource_uuid='id', drone_uuid='name', resource_status='status')
 
         translator_functions = StaticMapping(created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
                                              updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
@@ -51,7 +51,7 @@ class OpenStackAdapter(SiteAdapter):
                                        translator_functions=translator_functions)
 
     async def deploy_resource(self, resource_attributes):
-        specs = dict(name=resource_attributes.dns_name)
+        specs = dict(name=resource_attributes.drone_uuid)
         specs.update(self.configuration.MachineTypeConfiguration[self._machine_type])
         await self.nova.init_api(timeout=60)
         response = await self.nova.servers.create(server=specs)

--- a/tardis/adapters/sites/openstack.py
+++ b/tardis/adapters/sites/openstack.py
@@ -37,7 +37,7 @@ class OpenStackAdapter(SiteAdapter):
 
         self.nova = NovaClient(session=auth)
 
-        key_translator = StaticMapping(resource_id='id', dns_name='name', resource_status='status')
+        key_translator = StaticMapping(remote_resource_uuid='id', dns_name='name', resource_status='status')
 
         translator_functions = StaticMapping(created=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
                                              updated=lambda date: datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ"),
@@ -72,20 +72,20 @@ class OpenStackAdapter(SiteAdapter):
 
     async def resource_status(self, resource_attributes):
         await self.nova.init_api(timeout=60)
-        response = await self.nova.servers.get(resource_attributes.resource_id)
+        response = await self.nova.servers.get(resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} servers get returned {response}")
         return self.handle_response(response['server'])
 
     async def stop_resource(self, resource_attributes):
         await self.nova.init_api(timeout=60)
         params = {'os-stop': None}
-        response = await self.nova.servers.run_action(resource_attributes.resource_id, **params)
+        response = await self.nova.servers.run_action(resource_attributes.remote_resource_uuid, **params)
         logging.debug(f"{self.site_name} servers stop returned {response}")
         return response
 
     async def terminate_resource(self, resource_attributes):
         await self.nova.init_api(timeout=60)
-        response = await self.nova.servers.force_delete(resource_attributes.resource_id)
+        response = await self.nova.servers.force_delete(resource_attributes.remote_resource_uuid)
         logging.debug(f"{self.site_name} servers terminate returned {response}")
         return response
 

--- a/tardis/agents/batchsystemagent.py
+++ b/tardis/agents/batchsystemagent.py
@@ -5,20 +5,20 @@ class BatchSystemAgent(BatchSystemAdapter):
     def __init__(self, batch_system_adapter):
         self._batch_system_adapter = batch_system_adapter
 
-    async def disintegrate_machine(self, dns_name):
-        return await self._batch_system_adapter.disintegrate_machine(dns_name)
+    async def disintegrate_machine(self, drone_uuid):
+        return await self._batch_system_adapter.disintegrate_machine(drone_uuid)
 
-    async def drain_machine(self, dns_name):
-        return await self._batch_system_adapter.drain_machine(dns_name)
+    async def drain_machine(self, drone_uuid):
+        return await self._batch_system_adapter.drain_machine(drone_uuid)
 
-    async def integrate_machine(self, dns_name):
-        return await self._batch_system_adapter.integrate_machine(dns_name)
+    async def integrate_machine(self, drone_uuid):
+        return await self._batch_system_adapter.integrate_machine(drone_uuid)
 
-    async def get_allocation(self, dns_name):
-        return await self._batch_system_adapter.get_allocation(dns_name)
+    async def get_allocation(self, drone_uuid):
+        return await self._batch_system_adapter.get_allocation(drone_uuid)
 
-    async def get_machine_status(self, dns_name=None):
-        return await self._batch_system_adapter.get_machine_status(dns_name)
+    async def get_machine_status(self, drone_uuid):
+        return await self._batch_system_adapter.get_machine_status(drone_uuid)
 
-    async def get_utilization(self, dns_name):
-        return await self._batch_system_adapter.get_utilization(dns_name)
+    async def get_utilization(self, drone_uuid):
+        return await self._batch_system_adapter.get_utilization(drone_uuid)

--- a/tardis/agents/siteagent.py
+++ b/tardis/agents/siteagent.py
@@ -11,8 +11,8 @@ class SiteAgent(SiteAdapter):
             response = await self._site_adapter.deploy_resource(resource_attributes=resource_attributes)
             return convert_to_attribute_dict(response)
 
-    def dns_name(self, unique_id):
-        return self._site_adapter.dns_name(unique_id=unique_id)
+    def drone_uuid(self, uuid):
+        return self._site_adapter.drone_uuid(uuid=uuid)
 
     def handle_exceptions(self):
         return self._site_adapter.handle_exceptions()

--- a/tardis/interfaces/batchsystemadapter.py
+++ b/tardis/interfaces/batchsystemadapter.py
@@ -12,25 +12,25 @@ class MachineStatus(Enum):
 
 class BatchSystemAdapter(metaclass=ABCMeta):
     @abstractmethod
-    async def disintegrate_machine(self, dns_name):
+    async def disintegrate_machine(self, drone_uuid):
         return NotImplemented
 
     @abstractmethod
-    async def drain_machine(self, dns_name):
+    async def drain_machine(self, drone_uuid):
         return NotImplemented
 
     @abstractmethod
-    async def integrate_machine(self, dns_name):
+    async def integrate_machine(self, drone_uuid):
         return NotImplemented
 
     @abstractmethod
-    async def get_allocation(self, dns_name):
+    async def get_allocation(self, drone_uuid):
         return NotImplemented
 
     @abstractmethod
-    async def get_machine_status(self, dns_name):
+    async def get_machine_status(self, drone_uuid):
         return NotImplemented
 
     @abstractmethod
-    async def get_utilization(self, dns_name):
+    async def get_utilization(self, drone_uuid):
         return NotImplemented

--- a/tardis/interfaces/siteadapter.py
+++ b/tardis/interfaces/siteadapter.py
@@ -17,8 +17,8 @@ class SiteAdapter(metaclass=ABCMeta):
     async def deploy_resource(self, resource_attributes):
         return NotImplemented
 
-    def dns_name(self, unique_id):
-        return f"{self.site_name.lower()}-{unique_id}"
+    def drone_uuid(self, uuid):
+        return f"{self.site_name.lower()}-{uuid}"
 
     def handle_exceptions(self):
         return NotImplemented

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -47,7 +47,7 @@ class SqliteRegistry(Plugin):
                                    'FOREIGN KEY(site_id) REFERENCES Sites(site_id)'],
                   'Resources': ['id INTEGER PRIMARY KEY AUTOINCREMENT,'
                                 'remote_resource_uuid VARCHAR(255) UNIQUE',
-                                'dns_name VARCHAR(255) UNIQUE',
+                                'drone_uuid VARCHAR(255) UNIQUE',
                                 'state_id INTEGER',
                                 'site_id INTEGER',
                                 'machine_type_id INTEGER',
@@ -75,7 +75,7 @@ class SqliteRegistry(Plugin):
 
     async def delete_resource(self, bind_parameters):
         sql_query = """DELETE FROM Resources
-        WHERE dns_name = :dns_name
+        WHERE drone_uuid = :drone_uuid
         AND site_id = (SELECT site_id from Sites WHERE site_name = :site_name)"""
         await self.async_execute(sql_query, bind_parameters)
 
@@ -88,7 +88,7 @@ class SqliteRegistry(Plugin):
             return cursor.fetchall()
 
     def get_resources(self, site_name, machine_type):
-        sql_query = """SELECT R.remote_resource_uuid, R.dns_name, RS.state, R.created, R.updated
+        sql_query = """SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, R.created, R.updated
         FROM Resources R
         JOIN ResourceStates RS ON R.state_id = RS.state_id
         JOIN Sites S ON R.site_id = S.site_id
@@ -98,8 +98,8 @@ class SqliteRegistry(Plugin):
 
     async def insert_resource(self, bind_parameters):
         sql_query = """INSERT OR IGNORE INTO
-        Resources(remote_resource_uuid, dns_name, state_id, site_id, machine_type_id, created, updated)
-        SELECT :remote_resource_uuid, :dns_name, RS.state_id, S.site_id, MT.machine_type_id, :created, :updated
+        Resources(remote_resource_uuid, drone_uuid, state_id, site_id, machine_type_id, created, updated)
+        SELECT :remote_resource_uuid, :drone_uuid, RS.state_id, S.site_id, MT.machine_type_id, :created, :updated
         FROM ResourceStates RS
         JOIN Sites S ON S.site_name = :site_name
         JOIN MachineTypes MT ON MT.machine_type = :machine_type AND MT.site_id = S.site_id
@@ -116,6 +116,6 @@ class SqliteRegistry(Plugin):
     async def update_resource(self, bind_parameters):
         sql_query = """UPDATE Resources SET updated = :updated,
         state_id = (SELECT state_id FROM ResourceStates WHERE state = :state)
-        WHERE dns_name = :dns_name
+        WHERE drone_uuid = :drone_uuid
         AND site_id = (SELECT site_id FROM Sites WHERE site_name = :site_name)"""
         await self.async_execute(sql_query, bind_parameters)

--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -46,7 +46,7 @@ class SqliteRegistry(Plugin):
                                    'site_id INTEGER',
                                    'FOREIGN KEY(site_id) REFERENCES Sites(site_id)'],
                   'Resources': ['id INTEGER PRIMARY KEY AUTOINCREMENT,'
-                                'resource_id VARCHAR(255) UNIQUE',
+                                'remote_resource_uuid VARCHAR(255) UNIQUE',
                                 'dns_name VARCHAR(255) UNIQUE',
                                 'state_id INTEGER',
                                 'site_id INTEGER',
@@ -88,7 +88,7 @@ class SqliteRegistry(Plugin):
             return cursor.fetchall()
 
     def get_resources(self, site_name, machine_type):
-        sql_query = """SELECT R.resource_id, R.dns_name, RS.state, R.created, R.updated
+        sql_query = """SELECT R.remote_resource_uuid, R.dns_name, RS.state, R.created, R.updated
         FROM Resources R
         JOIN ResourceStates RS ON R.state_id = RS.state_id
         JOIN Sites S ON R.site_id = S.site_id
@@ -98,8 +98,8 @@ class SqliteRegistry(Plugin):
 
     async def insert_resource(self, bind_parameters):
         sql_query = """INSERT OR IGNORE INTO
-        Resources(resource_id, dns_name, state_id, site_id, machine_type_id, created, updated)
-        SELECT :resource_id, :dns_name, RS.state_id, S.site_id, MT.machine_type_id, :created, :updated
+        Resources(remote_resource_uuid, dns_name, state_id, site_id, machine_type_id, created, updated)
+        SELECT :remote_resource_uuid, :dns_name, RS.state_id, S.site_id, MT.machine_type_id, :created, :updated
         FROM ResourceStates RS
         JOIN Sites S ON S.site_name = :site_name
         JOIN MachineTypes MT ON MT.machine_type = :machine_type AND MT.site_id = S.site_id

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -13,7 +13,7 @@ import uuid
 
 @service(flavour=asyncio)
 class Drone(Pool):
-    def __init__(self, site_agent, batch_system_agent, plugins=None, resource_id=None, dns_name=None,
+    def __init__(self, site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, dns_name=None,
                  state=RequestState(), created=None, updated=None):
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
@@ -22,7 +22,7 @@ class Drone(Pool):
 
         self.resource_attributes = AttributeDict(site_name=self._site_agent.site_name,
                                                  machine_type=self.site_agent.machine_type,
-                                                 resource_id=resource_id,
+                                                 remote_resource_uuid=remote_resource_uuid,
                                                  created=created or datetime.now(),
                                                  updated=updated or datetime.now(),
                                                  dns_name=dns_name or self.site_agent.dns_name(uuid.uuid4().hex[:10]))

--- a/tardis/resources/drone.py
+++ b/tardis/resources/drone.py
@@ -13,7 +13,7 @@ import uuid
 
 @service(flavour=asyncio)
 class Drone(Pool):
-    def __init__(self, site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, dns_name=None,
+    def __init__(self, site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, drone_uuid=None,
                  state=RequestState(), created=None, updated=None):
         self._site_agent = site_agent
         self._batch_system_agent = batch_system_agent
@@ -25,7 +25,8 @@ class Drone(Pool):
                                                  remote_resource_uuid=remote_resource_uuid,
                                                  created=created or datetime.now(),
                                                  updated=updated or datetime.now(),
-                                                 dns_name=dns_name or self.site_agent.dns_name(uuid.uuid4().hex[:10]))
+                                                 drone_uuid=drone_uuid or self.site_agent.drone_uuid(
+                                                     uuid.uuid4().hex[:10]))
 
         self._allocation = 0.0
         self._demand = self.maximum_demand
@@ -69,7 +70,7 @@ class Drone(Pool):
             await self.state.run(self)
             await asyncio.sleep(60)
             if isinstance(self.state, DownState):
-                logging.debug(f"Garbage Collect Drone: {self.resource_attributes.dns_name}")
+                logging.debug(f"Garbage Collect Drone: {self.resource_attributes.drone_uuid}")
                 self._demand = 0
                 return
 

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -14,8 +14,8 @@ import logging
 
 
 async def batchsystem_machine_status(state_transition, drone, current_state):
-    machine_status = await drone.batch_system_agent.get_machine_status(dns_name=drone.resource_attributes[
-        'dns_name'])
+    machine_status = await drone.batch_system_agent.get_machine_status(
+        drone_uuid=drone.resource_attributes['drone_uuid'])
     return state_transition[machine_status]()
 
 
@@ -66,7 +66,7 @@ class IntegrateState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in IntegrateState")
-        await drone.batch_system_agent.integrate_machine(dns_name=drone.resource_attributes['dns_name'])
+        await drone.batch_system_agent.integrate_machine(drone_uuid=drone.resource_attributes['drone_uuid'])
         await drone.set_state(IntegratingState())  # static state transition
 
 
@@ -110,10 +110,10 @@ class AvailableState(State):
         new_state = await cls.run_processing_pipeline(drone)
 
         if isinstance(new_state, AvailableState):
-            drone._allocation = await drone.batch_system_agent.get_allocation(dns_name=drone.resource_attributes[
-                'dns_name'])
-            drone._utilisation = await drone.batch_system_agent.get_utilization(dns_name=drone.resource_attributes[
-                'dns_name'])
+            drone._allocation = await drone.batch_system_agent.get_allocation(
+                drone_uuid=drone.resource_attributes['drone_uuid'])
+            drone._utilisation = await drone.batch_system_agent.get_utilization(
+                drone_uuid=drone.resource_attributes['drone_uuid'])
             drone._supply = drone.maximum_demand
 
         await drone.set_state(new_state)
@@ -123,8 +123,7 @@ class DrainState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in DrainState")
-        await drone.batch_system_agent.drain_machine(dns_name=drone.resource_attributes[
-            'dns_name'])
+        await drone.batch_system_agent.drain_machine(drone_uuid=drone.resource_attributes['drone_uuid'])
         await asyncio.sleep(0.5)
         await drone.set_state(DrainingState())  # static state transition
 
@@ -149,7 +148,7 @@ class DisintegrateState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in DisintegrateState")
-        await drone.batch_system_agent.disintegrate_machine(dns_name=drone.resource_attributes['dns_name'])
+        await drone.batch_system_agent.disintegrate_machine(drone_uuid=drone.resource_attributes['drone_uuid'])
         await drone.set_state(ShutDownState())  # static state transition
 
 

--- a/tardis/resources/dronestates.py
+++ b/tardis/resources/dronestates.py
@@ -163,7 +163,7 @@ class ShutDownState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in ShutDownState")
-        logging.info(f'Stopping VM with ID {drone.resource_attributes.resource_id}')
+        logging.info(f'Stopping VM with ID {drone.resource_attributes.remote_resource_uuid}')
 
         new_state = await cls.run_processing_pipeline(drone)
 
@@ -181,7 +181,7 @@ class ShuttingDownState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in ShuttingDownState")
-        logging.info(f'Checking Status of VM with ID {drone.resource_attributes.resource_id}')
+        logging.info(f'Checking Status of VM with ID {drone.resource_attributes.remote_resource_uuid}')
         await drone.set_state(await cls.run_processing_pipeline(drone))
 
 
@@ -189,7 +189,7 @@ class CleanupState(State):
     @classmethod
     async def run(cls, drone):
         logging.info(f"Drone {drone} in CleanupState")
-        logging.info(f'Destroying VM with ID {drone.resource_attributes.resource_id}')
+        logging.info(f'Destroying VM with ID {drone.resource_attributes.remote_resource_uuid}')
         try:
             await drone.site_agent.terminate_resource(drone.resource_attributes)
         except TardisDroneCrashed:

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -61,10 +61,10 @@ def create_composite_pool(configuration='tardis.yml'):
     return WeightedComposite(*composites)
 
 
-def create_drone(site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, dns_name=None,
+def create_drone(site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, drone_uuid=None,
                  state=RequestState(), created=None, updated=None):
     return Drone(site_agent=site_agent, batch_system_agent=batch_system_agent, plugins=plugins,
-                 remote_resource_uuid=remote_resource_uuid, dns_name=dns_name, state=state,
+                 remote_resource_uuid=remote_resource_uuid, drone_uuid=drone_uuid, state=state,
                  created=created, updated=updated)
 
 

--- a/tardis/resources/poolfactory.py
+++ b/tardis/resources/poolfactory.py
@@ -61,10 +61,11 @@ def create_composite_pool(configuration='tardis.yml'):
     return WeightedComposite(*composites)
 
 
-def create_drone(site_agent, batch_system_agent, plugins=None, resource_id=None, dns_name=None,
+def create_drone(site_agent, batch_system_agent, plugins=None, remote_resource_uuid=None, dns_name=None,
                  state=RequestState(), created=None, updated=None):
     return Drone(site_agent=site_agent, batch_system_agent=batch_system_agent, plugins=plugins,
-                 resource_id=resource_id, dns_name=dns_name, state=state, created=created, updated=updated)
+                 remote_resource_uuid=remote_resource_uuid, dns_name=dns_name, state=state,
+                 created=created, updated=updated)
 
 
 def get_drones_to_restore(plugins, site, machine_type):

--- a/tests/adapters_t/batchsystems_t/test_htcondor.py
+++ b/tests/adapters_t/batchsystems_t/test_htcondor.py
@@ -46,55 +46,55 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.reset_mock()
 
     def test_disintegrate_machine(self):
-        self.assertIsNone(run_async(self.htcondor_adapter.disintegrate_machine, dns_name='test'))
+        self.assertIsNone(run_async(self.htcondor_adapter.disintegrate_machine, drone_uuid='test'))
 
     def test_drain_machine(self):
-        run_async(self.htcondor_adapter.drain_machine, dns_name='test')
+        run_async(self.htcondor_adapter.drain_machine, drone_uuid='test')
         self.mock_async_run_command.assert_called_with('condor_drain -graceful test')
-        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="not_exists"))
+        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="not_exists"))
         self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Does not exists",
                                                                          error_code=1,
                                                                          error_message="Does not exists")
-        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="test"))
+        self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
 
         self.mock_async_run_command.side_effect = AsyncRunCommandFailure(message="Unhandled error",
                                                                          error_code=2,
                                                                          error_message="Unhandled error")
         with self.assertRaises(AsyncRunCommandFailure):
-            self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, dns_name="test"))
+            self.assertIsNone(run_async(self.htcondor_adapter.drain_machine, drone_uuid="test"))
 
         self.mock_async_run_command.side_effect = None
 
     def test_integrate_machine(self):
-        self.assertIsNone(run_async(self.htcondor_adapter.integrate_machine, dns_name='test'))
+        self.assertIsNone(run_async(self.htcondor_adapter.integrate_machine, drone_uuid='test'))
 
     def test_get_resource_ratios(self):
-        self.assertCountEqual(list(run_async(self.htcondor_adapter.get_resource_ratios, dns_name='test')),
+        self.assertCountEqual(list(run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid='test')),
                               [self.cpu_ratio, self.memory_ratio])
         self.mock_async_run_command.assert_called_with(self.command)
 
-        self.assertEqual(run_async(self.htcondor_adapter.get_resource_ratios, dns_name='not_exists'), {})
+        self.assertEqual(run_async(self.htcondor_adapter.get_resource_ratios, drone_uuid='not_exists'), {})
 
     def test_get_allocation(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_allocation, dns_name='test'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_allocation, drone_uuid='test'),
                          max([self.cpu_ratio, self.memory_ratio]))
         self.mock_async_run_command.assert_called_with(self.command)
 
     def test_get_machine_status(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, dns_name='test'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test'),
                          MachineStatus.Available)
         self.mock_async_run_command.assert_called_with(self.command)
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, dns_name='not_exists'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='not_exists'),
                          MachineStatus.NotAvailable)
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, dns_name='test_drain'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_drain'),
                          MachineStatus.Draining)
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, dns_name='test_drained'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_drained'),
                          MachineStatus.Drained)
         self.mock_async_run_command.reset_mock()
-        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, dns_name='test_owner'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_machine_status, drone_uuid='test_owner'),
                          MachineStatus.NotAvailable)
         self.mock_async_run_command.reset_mock()
 
@@ -106,6 +106,6 @@ class TestHTCondorAdapter(TestCase):
         self.mock_async_run_command.side_effect = None
 
     def test_get_utilization(self):
-        self.assertEqual(run_async(self.htcondor_adapter.get_utilization, dns_name='test'),
+        self.assertEqual(run_async(self.htcondor_adapter.get_utilization, drone_uuid='test'),
                          min([self.cpu_ratio, self.memory_ratio]))
         self.mock_async_run_command.assert_called_with(self.command)

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -65,7 +65,7 @@ class TestCloudStackAdapter(TestCase):
     def test_deploy_resource(self):
         self.assertEqual(run_async(self.cloudstack_adapter.deploy_resource,
                                    resource_attributes=AttributeDict(dns_name='testsite-089123')),
-                         AttributeDict(dns_name='testsite-089123', resource_id='123456',
+                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='123456',
                                        resource_status=ResourceStatus.Booting))
 
         self.mock_cloudstack_api.return_value.deployVirtualMachine.assert_called_with(
@@ -84,20 +84,20 @@ class TestCloudStackAdapter(TestCase):
 
     def test_resource_status(self):
         self.assertEqual(run_async(self.cloudstack_adapter.resource_status,
-                                   resource_attributes=AttributeDict(resource_id='123456')),
-                         AttributeDict(dns_name='testsite-089123', resource_id='123456',
+                                   resource_attributes=AttributeDict(remote_resource_uuid='123456')),
+                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='123456',
                                        resource_status=ResourceStatus.Running))
         self.mock_cloudstack_api.return_value.listVirtualMachines.assert_called_with(id='123456')
 
     def test_stop_resource(self):
         run_async(self.cloudstack_adapter.stop_resource,
-                  resource_attributes=AttributeDict(resource_id='123456'))
+                  resource_attributes=AttributeDict(remote_resource_uuid='123456'))
 
         self.mock_cloudstack_api.return_value.stopVirtualMachine.assert_called_with(id='123456')
 
     def test_terminate_resource(self):
         run_async(self.cloudstack_adapter.terminate_resource,
-                  resource_attributes=AttributeDict(resource_id='123456'))
+                  resource_attributes=AttributeDict(remote_resource_uuid='123456'))
 
         self.mock_cloudstack_api.return_value.destroyVirtualMachine.assert_called_with(id='123456')
 

--- a/tests/adapters_t/sites_t/test_cloudstack.py
+++ b/tests/adapters_t/sites_t/test_cloudstack.py
@@ -64,8 +64,8 @@ class TestCloudStackAdapter(TestCase):
 
     def test_deploy_resource(self):
         self.assertEqual(run_async(self.cloudstack_adapter.deploy_resource,
-                                   resource_attributes=AttributeDict(dns_name='testsite-089123')),
-                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='123456',
+                                   resource_attributes=AttributeDict(drone_uuid='testsite-089123')),
+                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='123456',
                                        resource_status=ResourceStatus.Booting))
 
         self.mock_cloudstack_api.return_value.deployVirtualMachine.assert_called_with(
@@ -85,7 +85,7 @@ class TestCloudStackAdapter(TestCase):
     def test_resource_status(self):
         self.assertEqual(run_async(self.cloudstack_adapter.resource_status,
                                    resource_attributes=AttributeDict(remote_resource_uuid='123456')),
-                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='123456',
+                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='123456',
                                        resource_status=ResourceStatus.Running))
         self.mock_cloudstack_api.return_value.listVirtualMachines.assert_called_with(id='123456')
 

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -173,7 +173,7 @@ class TestMoabAdapter(TestCase):
                              resource_status=ResourceStatus.Booting,
                              created=datetime.strptime("Wed Jan 23 2019 15:01:47", '%a %b %d %Y %H:%M:%S'),
                              updated=datetime.strptime("Wed Jan 23 2019 15:02:17", '%a %b %d %Y %H:%M:%S'),
-                             dns_name='testsite-4761849')
+                             drone_uuid='testsite-4761849')
 
     @mock_executor_run_command(TEST_DEPLOY_RESOURCE_RESPONSE)
     def test_deploy_resource(self):

--- a/tests/adapters_t/sites_t/test_moab.py
+++ b/tests/adapters_t/sites_t/test_moab.py
@@ -169,7 +169,7 @@ class TestMoabAdapter(TestCase):
     def resource_attributes(self):
         return AttributeDict(machine_type='test2large',
                              site_name='TestSite',
-                             resource_id=4761849,
+                             remote_resource_uuid=4761849,
                              resource_status=ResourceStatus.Booting,
                              created=datetime.strptime("Wed Jan 23 2019 15:01:47", '%a %b %d %Y %H:%M:%S'),
                              updated=datetime.strptime("Wed Jan 23 2019 15:02:17", '%a %b %d %Y %H:%M:%S'),
@@ -276,6 +276,6 @@ class TestMoabAdapter(TestCase):
         for to_raise, to_catch in matrix:
             test_exception_handling(to_raise, to_catch)
 
-    def test_check_resource_id(self):
+    def test_check_remote_resource_uuid(self):
         with self.assertRaises(TardisError):
-            self.moab_adapter.check_resource_id(AttributeDict(resource_id=1), regex=r"^(\d)$", response="2")
+            self.moab_adapter.check_remote_resource_uuid(AttributeDict(remote_resource_uuid=1), regex=r"^(\d)$", response="2")

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -68,8 +68,8 @@ class TestOpenStackAdapter(TestCase):
 
     def test_deploy_resource(self):
         self.assertEqual(run_async(self.openstack_adapter.deploy_resource,
-                                   resource_attributes=AttributeDict(dns_name='testsite-089123')),
-                         AttributeDict(dns_name='testsite-089123'))
+                                   resource_attributes=AttributeDict(drone_uuid='testsite-089123')),
+                         AttributeDict(drone_uuid='testsite-089123'))
 
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
 
@@ -88,7 +88,7 @@ class TestOpenStackAdapter(TestCase):
     def test_resource_status(self):
         self.assertEqual(run_async(self.openstack_adapter.resource_status,
                                    resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123')),
-                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='029312-1231-123123',
+                         AttributeDict(drone_uuid='testsite-089123', remote_resource_uuid='029312-1231-123123',
                                        resource_status=ResourceStatus.Running))
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
         self.mock_openstack_api.return_value.servers.get.assert_called_with('029312-1231-123123')

--- a/tests/adapters_t/sites_t/test_openstack.py
+++ b/tests/adapters_t/sites_t/test_openstack.py
@@ -87,22 +87,22 @@ class TestOpenStackAdapter(TestCase):
 
     def test_resource_status(self):
         self.assertEqual(run_async(self.openstack_adapter.resource_status,
-                                   resource_attributes=AttributeDict(resource_id='029312-1231-123123')),
-                         AttributeDict(dns_name='testsite-089123', resource_id='029312-1231-123123',
+                                   resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123')),
+                         AttributeDict(dns_name='testsite-089123', remote_resource_uuid='029312-1231-123123',
                                        resource_status=ResourceStatus.Running))
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
         self.mock_openstack_api.return_value.servers.get.assert_called_with('029312-1231-123123')
 
     def test_stop_resource(self):
         run_async(self.openstack_adapter.stop_resource,
-                  resource_attributes=AttributeDict(resource_id='029312-1231-123123'))
+                  resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123'))
         params = {'os-stop': None}
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
         self.mock_openstack_api.return_value.servers.run_action.assert_called_with('029312-1231-123123', **params)
 
     def test_terminate_resource(self):
         run_async(self.openstack_adapter.terminate_resource,
-                  resource_attributes=AttributeDict(resource_id='029312-1231-123123'))
+                  resource_attributes=AttributeDict(remote_resource_uuid='029312-1231-123123'))
 
         self.mock_openstack_api.return_value.init_api.assert_called_with(timeout=60)
         self.mock_openstack_api.return_value.servers.force_delete.assert_called_with('029312-1231-123123')

--- a/tests/agents_t/test_batchsystemagent.py
+++ b/tests/agents_t/test_batchsystemagent.py
@@ -14,30 +14,30 @@ class TestBatchSystemAgent(TestCase):
 
     def test_disintegrate_machine(self):
         self.batch_system_adapter.disintegrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.disintegrate_machine, dns_name='test')
+        run_async(self.batch_system_agent.disintegrate_machine, drone_uuid='test')
         self.batch_system_adapter.disintegrate_machine.assert_called_with('test')
 
     def test_drain_machine(self):
         self.batch_system_adapter.drain_machine.side_effect = async_return
-        run_async(self.batch_system_agent.drain_machine, dns_name='test')
+        run_async(self.batch_system_agent.drain_machine, drone_uuid='test')
         self.batch_system_adapter.drain_machine.assert_called_with('test')
 
     def test_integrate_machine(self):
         self.batch_system_adapter.integrate_machine.side_effect = async_return
-        run_async(self.batch_system_agent.integrate_machine, dns_name='test')
+        run_async(self.batch_system_agent.integrate_machine, drone_uuid='test')
         self.batch_system_adapter.integrate_machine.assert_called_with('test')
 
     def test_get_allocation(self):
         self.batch_system_adapter.get_allocation.side_effect = async_return
-        run_async(self.batch_system_agent.get_allocation, dns_name='test')
+        run_async(self.batch_system_agent.get_allocation, drone_uuid='test')
         self.batch_system_adapter.get_allocation.assert_called_with('test')
 
     def test_get_machine_status(self):
         self.batch_system_adapter.get_machine_status.side_effect = async_return
-        run_async(self.batch_system_agent.get_machine_status, dns_name='test')
+        run_async(self.batch_system_agent.get_machine_status, drone_uuid='test')
         self.batch_system_adapter.get_machine_status.assert_called_with('test')
 
     def test_get_utilization(self):
         self.batch_system_adapter.get_utilization.side_effect = async_return
-        run_async(self.batch_system_agent.get_utilization, dns_name='test')
+        run_async(self.batch_system_agent.get_utilization, drone_uuid='test')
         self.batch_system_adapter.get_utilization.assert_called_with('test')

--- a/tests/agents_t/test_siteagent.py
+++ b/tests/agents_t/test_siteagent.py
@@ -18,10 +18,10 @@ class TestSiteAgent(TestCase):
         run_async(self.site_agent.deploy_resource, resource_attributes="test")
         self.site_adapter.deploy_resource.assert_called_with(resource_attributes='test')
 
-    def test_dns_name(self):
-        self.site_adapter.dns_name.return_value = None
-        self.site_agent.dns_name(unique_id="test")
-        self.site_adapter.dns_name.assert_called_with(unique_id='test')
+    def test_drone_uuid(self):
+        self.site_adapter.drone_uuid.return_value = None
+        self.site_agent.drone_uuid(uuid="test")
+        self.site_adapter.drone_uuid.assert_called_with(uuid='test')
 
     def test_handle_exceptions(self):
         self.site_adapter.handle_exceptions.return_value = None

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -22,26 +22,26 @@ class TestSqliteRegistry(TestCase):
         cls.test_machine_type = 'MyGreatTestMachineType'
         cls.tables_in_db = {'MachineTypes', 'Resources', 'ResourceStates', 'Sites'}
         cls.test_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
-                                        'dns_name': f'{cls.test_site_name}-07af52405e',
+                                        'drone_uuid': f'{cls.test_site_name}-07af52405e',
                                         'site_name': cls.test_site_name,
                                         'machine_type': cls.test_machine_type,
                                         'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
                                         'updated': datetime.datetime(2018, 11, 16, 15, 49, 58)}
         cls.test_updated_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
-                                                'dns_name': f'{cls.test_site_name}-07af52405e',
+                                                'drone_uuid': f'{cls.test_site_name}-07af52405e',
                                                 'site_name': cls.test_site_name,
                                                 'machine_type': cls.test_machine_type,
                                                 'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
                                                 'updated': datetime.datetime(2018, 11, 16, 15, 50, 58)}
 
         cls.test_get_resources_result = {'remote_resource_uuid': cls.test_resource_attributes['remote_resource_uuid'],
-                                         'dns_name': cls.test_resource_attributes['dns_name'],
+                                         'drone_uuid': cls.test_resource_attributes['drone_uuid'],
                                          'state': str(BootingState()),
                                          'created': str(cls.test_resource_attributes['created']),
                                          'updated': str(cls.test_resource_attributes['updated'])}
 
         cls.test_notify_result = (cls.test_resource_attributes['remote_resource_uuid'],
-                                  cls.test_resource_attributes['dns_name'],
+                                  cls.test_resource_attributes['drone_uuid'],
                                   str(BootingState()),
                                   cls.test_resource_attributes['site_name'],
                                   cls.test_resource_attributes['machine_type'],
@@ -49,7 +49,7 @@ class TestSqliteRegistry(TestCase):
                                   str(cls.test_resource_attributes['updated']))
 
         cls.test_updated_notify_result = (cls.test_updated_resource_attributes['remote_resource_uuid'],
-                                          cls.test_updated_resource_attributes['dns_name'],
+                                          cls.test_updated_resource_attributes['drone_uuid'],
                                           str(IntegrateState()),
                                           cls.test_updated_resource_attributes['site_name'],
                                           cls.test_updated_resource_attributes['machine_type'],
@@ -127,8 +127,8 @@ class TestSqliteRegistry(TestCase):
         def fetch_row(db):
             with sqlite3.connect(db) as connection:
                 cursor = connection.cursor()
-                cursor.execute("""SELECT R.remote_resource_uuid, R.dns_name, RS.state, S.site_name, MT.machine_type, R.created,
-                R.updated
+                cursor.execute("""SELECT R.remote_resource_uuid, R.drone_uuid, RS.state, S.site_name, MT.machine_type, 
+                R.created, R.updated
                 FROM Resources R
                 JOIN ResourceStates RS ON R.state_id = RS.state_id
                 JOIN Sites S ON R.site_id = S.site_id

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -21,26 +21,26 @@ class TestSqliteRegistry(TestCase):
         cls.test_site_name = 'MyGreatTestSite'
         cls.test_machine_type = 'MyGreatTestMachineType'
         cls.tables_in_db = {'MachineTypes', 'Resources', 'ResourceStates', 'Sites'}
-        cls.test_resource_attributes = {'resource_id': 'bf85022b-fdd6-42b1-932d-086c288d4755',
+        cls.test_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
                                         'dns_name': f'{cls.test_site_name}-07af52405e',
                                         'site_name': cls.test_site_name,
                                         'machine_type': cls.test_machine_type,
                                         'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
                                         'updated': datetime.datetime(2018, 11, 16, 15, 49, 58)}
-        cls.test_updated_resource_attributes = {'resource_id': 'bf85022b-fdd6-42b1-932d-086c288d4755',
+        cls.test_updated_resource_attributes = {'remote_resource_uuid': 'bf85022b-fdd6-42b1-932d-086c288d4755',
                                                 'dns_name': f'{cls.test_site_name}-07af52405e',
                                                 'site_name': cls.test_site_name,
                                                 'machine_type': cls.test_machine_type,
                                                 'created': datetime.datetime(2018, 11, 16, 15, 49, 58),
                                                 'updated': datetime.datetime(2018, 11, 16, 15, 50, 58)}
 
-        cls.test_get_resources_result = {'resource_id': cls.test_resource_attributes['resource_id'],
+        cls.test_get_resources_result = {'remote_resource_uuid': cls.test_resource_attributes['remote_resource_uuid'],
                                          'dns_name': cls.test_resource_attributes['dns_name'],
                                          'state': str(BootingState()),
                                          'created': str(cls.test_resource_attributes['created']),
                                          'updated': str(cls.test_resource_attributes['updated'])}
 
-        cls.test_notify_result = (cls.test_resource_attributes['resource_id'],
+        cls.test_notify_result = (cls.test_resource_attributes['remote_resource_uuid'],
                                   cls.test_resource_attributes['dns_name'],
                                   str(BootingState()),
                                   cls.test_resource_attributes['site_name'],
@@ -48,7 +48,7 @@ class TestSqliteRegistry(TestCase):
                                   str(cls.test_resource_attributes['created']),
                                   str(cls.test_resource_attributes['updated']))
 
-        cls.test_updated_notify_result = (cls.test_updated_resource_attributes['resource_id'],
+        cls.test_updated_notify_result = (cls.test_updated_resource_attributes['remote_resource_uuid'],
                                           cls.test_updated_resource_attributes['dns_name'],
                                           str(IntegrateState()),
                                           cls.test_updated_resource_attributes['site_name'],
@@ -127,7 +127,7 @@ class TestSqliteRegistry(TestCase):
         def fetch_row(db):
             with sqlite3.connect(db) as connection:
                 cursor = connection.cursor()
-                cursor.execute("""SELECT R.resource_id, R.dns_name, RS.state, S.site_name, MT.machine_type, R.created,
+                cursor.execute("""SELECT R.remote_resource_uuid, R.dns_name, RS.state, S.site_name, MT.machine_type, R.created,
                 R.updated
                 FROM Resources R
                 JOIN ResourceStates RS ON R.state_id = RS.state_id

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -46,7 +46,7 @@ class TestDroneStates(TestCase):
             return f
 
         self.drone = self.mock_drone.return_value
-        self.drone.resource_attributes = AttributeDict(dns_name='test-923ABF', remote_resource_uuid='0815')
+        self.drone.resource_attributes = AttributeDict(drone_uuid='test-923ABF', remote_resource_uuid='0815')
         self.drone.demand = 8.0
         self.drone._supply = 8.0
         self.drone.set_state.side_effect = partial(mock_set_state, self.drone)
@@ -111,7 +111,7 @@ class TestDroneStates(TestCase):
         self.drone.state.return_value = IntegrateState
         run_async(self.drone.state.return_value.run, self.drone)
         self.assertIsInstance(self.drone.state, IntegratingState)
-        self.drone.batch_system_agent.integrate_machine.assert_called_with(dns_name='test-923ABF')
+        self.drone.batch_system_agent.integrate_machine.assert_called_with(drone_uuid='test-923ABF')
 
     def test_integrating_state(self):
 
@@ -150,7 +150,7 @@ class TestDroneStates(TestCase):
         self.drone.state.return_value = DrainState
         run_async(self.drone.state.return_value.run, self.drone)
         self.assertIsInstance(self.drone.state, DrainingState)
-        self.drone.batch_system_agent.drain_machine.assert_called_with(dns_name='test-923ABF')
+        self.drone.batch_system_agent.drain_machine.assert_called_with(drone_uuid='test-923ABF')
 
     def test_draining_state(self):
         matrix = [(ResourceStatus.Running, MachineStatus.Draining, DrainingState),
@@ -166,7 +166,7 @@ class TestDroneStates(TestCase):
         self.drone.state.return_value = DisintegrateState
         run_async(self.drone.state.return_value.run, self.drone)
         self.assertIsInstance(self.drone.state, ShutDownState)
-        self.drone.batch_system_agent.disintegrate_machine.assert_called_with(dns_name='test-923ABF')
+        self.drone.batch_system_agent.disintegrate_machine.assert_called_with(drone_uuid='test-923ABF')
 
     def test_shutdown_state(self):
         matrix = [(ResourceStatus.Running, None, ShuttingDownState),

--- a/tests/resources_t/test_dronestates.py
+++ b/tests/resources_t/test_dronestates.py
@@ -46,7 +46,7 @@ class TestDroneStates(TestCase):
             return f
 
         self.drone = self.mock_drone.return_value
-        self.drone.resource_attributes = AttributeDict(dns_name='test-923ABF', resource_id='0815')
+        self.drone.resource_attributes = AttributeDict(dns_name='test-923ABF', remote_resource_uuid='0815')
         self.drone.demand = 8.0
         self.drone._supply = 8.0
         self.drone.set_state.side_effect = partial(mock_set_state, self.drone)

--- a/tests/resources_t/test_poolfactory.py
+++ b/tests/resources_t/test_poolfactory.py
@@ -30,10 +30,10 @@ class TestPoolFactory(TestCase):
         sqlite_registry.get_resources.return_value = [{'state': 'RequestState'}]
 
     def test_str_to_state(self):
-        test = [{'state': 'RequestState', 'dns_name': 'test-abc123'}]
+        test = [{'state': 'RequestState', 'drone_uuid': 'test-abc123'}]
         converted_test = str_to_state(test)
         self.assertTrue(converted_test[0]['state'], RequestState)
-        self.assertEqual(converted_test[0]['dns_name'], 'test-abc123')
+        self.assertEqual(converted_test[0]['drone_uuid'], 'test-abc123')
 
     def test_load_plugins(self):
         self.assertEqual(load_plugins(), {'SqliteRegistry': self.mock_sqliteregistry()})


### PR DESCRIPTION
Currently, remote resources are identified in the overlay batch system by their dns names. However, adding existing computing resources like worker nodes in a HTCondor batch system see
#41, require a different unique identifier, since hostnames cannot be changed. This pull requests refactors the handling of unique identifiers. 

This pull request needs to be merged before #41 
