### PR TITLE
Sqlite registry should return datetime object instead of strings

### DIFF
--- a/tardis/plugins/sqliteregistry.py
+++ b/tardis/plugins/sqliteregistry.py
@@ -38,7 +38,7 @@ class SqliteRegistry(Plugin):
         return await loop.run_in_executor(self.thread_pool_executor, self.execute, sql_query, bind_parameters)
 
     def connect(self):
-        return sqlite3.connect(self._db_file)
+        return sqlite3.connect(self._db_file, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES)
 
     def _deploy_db_schema(self):
         tables = {'MachineTypes': ['machine_type_id INTEGER PRIMARY KEY AUTOINCREMENT',
@@ -51,8 +51,8 @@ class SqliteRegistry(Plugin):
                                 'state_id INTEGER',
                                 'site_id INTEGER',
                                 'machine_type_id INTEGER',
-                                'created DATE',
-                                'updated DATE',
+                                'created TIMESTAMP',
+                                'updated TIMESTAMP',
                                 'FOREIGN KEY(state_id) REFERENCES ResourceState(state_id)',
                                 'FOREIGN KEY(site_id) REFERENCES Sites(site_id)',
                                 'FOREIGN KEY(machine_type_id) REFERENCES MachineTypes(machine_type_id)'],

--- a/tests/plugins_t/test_sqliteregistry.py
+++ b/tests/plugins_t/test_sqliteregistry.py
@@ -37,8 +37,8 @@ class TestSqliteRegistry(TestCase):
         cls.test_get_resources_result = {'remote_resource_uuid': cls.test_resource_attributes['remote_resource_uuid'],
                                          'drone_uuid': cls.test_resource_attributes['drone_uuid'],
                                          'state': str(BootingState()),
-                                         'created': str(cls.test_resource_attributes['created']),
-                                         'updated': str(cls.test_resource_attributes['updated'])}
+                                         'created': cls.test_resource_attributes['created'],
+                                         'updated': cls.test_resource_attributes['updated']}
 
         cls.test_notify_result = (cls.test_resource_attributes['remote_resource_uuid'],
                                   cls.test_resource_attributes['drone_uuid'],


### PR DESCRIPTION
Sqlite registry currently returns a string for DATE columns instead of a datetime object. However, the site adapters require a datetime object instead. 
This pull requests changes the schema, to use SQL data type TIMESTAMP instead of DATE and makes use of the sqlite PARSE_DECLTYPES feature to return datatime objects. 